### PR TITLE
bump ubuntu version and pin rouge version

### DIFF
--- a/.github/workflows/preview-blog.yaml
+++ b/.github/workflows/preview-blog.yaml
@@ -5,15 +5,18 @@ on:
 
 jobs:
   preview:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
 
     - name: Install Ruby Dev                     
       run: sudo apt-get install ruby-dev
 
-    - name: Install AsciiDoctor and Rouge
-      run: sudo gem install asciidoctor rouge
+    - name: Install AsciiDoctor
+      run: sudo gem install asciidoctor
+      
+    - name: Install Rouge
+      run: sudo gem install rouge -v 3.30.0
 
     - name: Setup Hugo                           
       uses: peaceiris/actions-hugo@v2


### PR DESCRIPTION
Per https://github.com/rmoff/rmoff-blog/runs/8280063315?check_suite_focus=true#step:4:22

```
ERROR:  Error installing rouge:
	The last version of rouge (>= 0) to support your Ruby & RubyGems was 3.30.0. Try installing it with `gem install rouge -v 3.30.0`
	rouge requires Ruby version >= 2.7. The current ruby version is 2.5.0.
```

Per https://github.com/rmoff/rmoff-blog/actions/runs/3025842983

```
The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002
```