### PR TITLE
Fix broken links to pythian blog

### DIFF
--- a/content/post/collection-of-articles-on-how-to-write-a-good-conference-abstract.md
+++ b/content/post/collection-of-articles-on-how-to-write-a-good-conference-abstract.md
@@ -13,7 +13,7 @@ title = "Collection of Articles on How to Write a Good Conference Abstract"
 Here's a collection of useful articles that I've found over the years that give good advice on writing a good abstract, mistakes to avoid, etc: 
 
 * [Adam Machanic - Capturing Attention: Writing Great Session Descriptions](http://dataeducation.com/capturing-attention-writing-great-session-descriptions/)
-* [Gwen Shapira - Concrete Advice for Abstract Writers](http://www.pythian.com/blog/concrete-advice-for-abstract-writers/)
+* [Gwen Shapira - Concrete Advice for Abstract Writers](https://blog.pythian.com/concrete-advice-for-abstract-writers/)
 * [Kellyn Pot’Vin-Gorman - Abstracts, Reviews and Conferences, Oh My!](http://dbakevlar.com/2013/10/abstracts-reviews-and-conferences-oh-my/)
 * [Russ Unger - Conference Proposals that Don’t Suck](http://alistapart.com/article/conference-proposals-that-dont-suck)
 * [Martin Widlake - Tips on Submitting an Abstract to Conference](https://mwidlake.wordpress.com/2015/04/17/tips-on-submitting-an-abstract-to-conference/)

--- a/content/post/how-to-win-[or-at-least-not-suck]-at-the-conference-abstract-submission-game.adoc
+++ b/content/post/how-to-win-[or-at-least-not-suck]-at-the-conference-abstract-submission-game.adoc
@@ -44,7 +44,7 @@ Here are some concrete ways you can ensure you're doing everything to prepare yo
 1. READ THIS ADVICE! Not just mine, but all the other advice that's out there. You would be surprised how many people don't. A lot of this process is 'playing the game', and these kinds of blogs all spell out the rules to follow: 
 +
 ** http://dataeducation.com/capturing-attention-writing-great-session-descriptions/[Adam Machanic - Capturing Attention: Writing Great Session Descriptions]
-** http://www.pythian.com/blog/concrete-advice-for-abstract-writers/[Gwen Shapira - Concrete Advice for Abstract Writers]
+** https://blog.pythian.com/concrete-advice-for-abstract-writers/[Gwen Shapira - Concrete Advice for Abstract Writers]
 ** http://dbakevlar.com/2013/10/abstracts-reviews-and-conferences-oh-my/[Kellyn Pot’Vin-Gorman - Abstracts, Reviews and Conferences, Oh My!]
 ** http://alistapart.com/article/conference-proposals-that-dont-suck[Russ Unger - Conference Proposals that Don’t Suck]
 ** https://mwidlake.wordpress.com/2015/04/17/tips-on-submitting-an-abstract-to-conference/[Martin Widlake - Tips on Submitting an Abstract to Conference]


### PR DESCRIPTION
From www.pythian.com/blog to blog.pythian.com