### PR TITLE
Add light/dark mode theme toggle

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -6,4 +6,4 @@ subtitle: "✨ Data Engineering, Kafka, and other random geekery 🤓"
 ---
 ![Robin Moffatt](/images/2018/05/ksldn18-01.jpg)
 
-<a href="https://bsky.app/profile/rmoff.net"><b class="fa-brands fa-bluesky"></b></a>  _Robin Moffatt works on the DevRel team at Confluent. He likes writing about himself in the third person, eating good breakfasts, and drinking good beer._
+_Robin Moffatt works on the DevRel team at Confluent. He likes writing about himself in the third person, eating good breakfasts, and drinking good beer._

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,22 +1,684 @@
-/* Custom styles for rmoff blog */
+/* Custom styles for rmoff blog - Dark Theme */
 
-/* Import Domine font from Google Fonts */
-@import url('https://fonts.googleapis.com/css2?family=Domine:wght@400;500;600;700&display=swap');
+/* ============================================
+   PHASE 1: CSS Variables & Base Colors
+   ============================================ */
 
-/* Override headings to use Domine instead of Quattrocento Sans */
-h1, h2, h3, h4, h5, h6 {
-  font-family: 'Domine', Georgia, Times, serif !important;
+:root {
+  /* Background colors - talks-site dark palette */
+  --bg-primary: #0d1117;
+  --bg-secondary: #161b22;
+  --bg-card: #1c2128;
+  --bg-code: #21262d;
+  --bg-hover: #30363d;
+
+  /* Accent colors */
+  --accent-gold: #f0b429;
+  --accent-gold-dim: #c99a2e;
+  --accent-gold-bright: #ffc933;
+  --accent-gold-glow: rgba(240, 180, 41, 0.4);
+
+  /* Text colors */
+  --text-primary: #e6edf3;
+  --text-secondary: #8b949e;
+  --text-muted: #6e7681;
+
+  /* Border colors */
+  --border-default: #30363d;
+  --border-muted: #21262d;
+
+  /* Other */
+  --shadow-gold: 0 0 20px rgba(240, 180, 41, 0.3);
 }
 
-/* Override base body article font to use Domine instead of Spectral */
+/* Light theme overrides */
+[data-theme="light"] {
+  /* Background colors - light palette */
+  --bg-primary: #ffffff;
+  --bg-secondary: #f6f8fa;
+  --bg-card: #ffffff;
+  --bg-code: #f6f8fa;
+  --bg-hover: #eaeef2;
+
+  /* Accent colors - slightly darker for light bg contrast */
+  --accent-gold: #b08800;
+  --accent-gold-dim: #8a6b00;
+  --accent-gold-bright: #d4a200;
+  --accent-gold-glow: rgba(176, 136, 0, 0.3);
+
+  /* Text colors */
+  --text-primary: #24292f;
+  --text-secondary: #57606a;
+  --text-muted: #6e7681;
+
+  /* Border colors */
+  --border-default: #d0d7de;
+  --border-muted: #d8dee4;
+
+  /* Other */
+  --shadow-gold: 0 0 20px rgba(176, 136, 0, 0.2);
+}
+
+/* Light theme specific overrides */
+[data-theme="light"] .terminal-title {
+  background: rgba(255, 255, 255, 0.95) !important;
+}
+
+[data-theme="light"] .retro-card-date {
+  background: rgba(255, 255, 255, 0.9) !important;
+}
+
+[data-theme="light"] header.cover .bg-black-30 {
+  background-color: rgba(0, 0, 0, 0.3) !important;
+}
+
+/* Light mode nav - only apply background to nav outside header */
+[data-theme="light"] body > nav.bg-black,
+[data-theme="light"] body > nav.sans-serif {
+  background-color: var(--bg-secondary) !important;
+}
+
+/* Nav inside header should be transparent over the image */
+[data-theme="light"] header nav {
+  background-color: transparent !important;
+}
+
+[data-theme="light"] header nav a.near-white,
+[data-theme="light"] header nav a.link,
+[data-theme="light"] header nav button.near-white,
+[data-theme="light"] header nav #theme-toggle,
+[data-theme="light"] header nav #theme-toggle i {
+  color: #e6edf3 !important;
+}
+
+[data-theme="light"] footer.bg-black {
+  background-color: var(--bg-secondary) !important;
+}
+
+[data-theme="light"] footer p,
+[data-theme="light"] footer span,
+[data-theme="light"] footer a {
+  color: var(--text-secondary) !important;
+}
+
+[data-theme="light"] #hdr h1,
+[data-theme="light"] #hdr .f2,
+[data-theme="light"] #hdr h2,
+[data-theme="light"] #hdr .fw1 {
+  color: #e6edf3 !important;
+}
+
+[data-theme="light"] #hdr .terminal-title {
+  background: rgba(13, 17, 23, 0.95) !important;
+  color: #f0b429 !important;
+}
+
+[data-theme="light"] #hdr a.category,
+[data-theme="light"] #hdr a.near-white {
+  color: #e6edf3 !important;
+}
+
+[data-theme="light"] .near-white {
+  color: var(--text-primary) !important;
+}
+
+/* Light mode syntax highlighting - override inline styles from Monokai theme */
+[data-theme="light"] .highlight pre,
+[data-theme="light"] .rouge.highlight,
+[data-theme="light"] pre.rouge,
+[data-theme="light"] .listingblock pre {
+  background-color: #f6f8fa !important;
+  color: #24292f !important;
+}
+
+/* Override ALL inline-styled spans in code blocks for light mode */
+[data-theme="light"] pre span,
+[data-theme="light"] code span,
+[data-theme="light"] .highlight span,
+[data-theme="light"] .listingblock span {
+  background-color: transparent !important;
+  background: transparent !important;
+}
+
+/* Remap Monokai colors to light theme equivalents */
+/* #f8f8f2 (light gray text) -> dark text */
+[data-theme="light"] pre span[style*="color: #f8f8f2"],
+[data-theme="light"] code span[style*="color: #f8f8f2"] {
+  color: #24292f !important;
+}
+
+/* #f92672 (pink/red keywords) -> red */
+[data-theme="light"] pre span[style*="color: #f92672"],
+[data-theme="light"] code span[style*="color: #f92672"] {
+  color: #d73a49 !important;
+}
+
+/* #66d9ef (cyan keywords) -> blue */
+[data-theme="light"] pre span[style*="color: #66d9ef"],
+[data-theme="light"] code span[style*="color: #66d9ef"] {
+  color: #0550ae !important;
+}
+
+/* #e6db74 (yellow strings) -> dark blue */
+[data-theme="light"] pre span[style*="color: #e6db74"],
+[data-theme="light"] code span[style*="color: #e6db74"] {
+  color: #0a3069 !important;
+}
+
+/* #ae81ff (purple numbers) -> blue */
+[data-theme="light"] pre span[style*="color: #ae81ff"],
+[data-theme="light"] code span[style*="color: #ae81ff"] {
+  color: #0550ae !important;
+}
+
+/* #a6e22e (green) -> dark green */
+[data-theme="light"] pre span[style*="color: #a6e22e"],
+[data-theme="light"] code span[style*="color: #a6e22e"] {
+  color: #116329 !important;
+}
+
+/* #75715e (comments) -> gray */
+[data-theme="light"] pre span[style*="color: #75715e"],
+[data-theme="light"] code span[style*="color: #75715e"] {
+  color: #6e7781 !important;
+}
+
+/* #fd971f (orange) -> orange/brown */
+[data-theme="light"] pre span[style*="color: #fd971f"],
+[data-theme="light"] code span[style*="color: #fd971f"] {
+  color: #953800 !important;
+}
+
+/* Also handle class-based highlighting */
+[data-theme="light"] .highlight .k,
+[data-theme="light"] .highlight .kd,
+[data-theme="light"] .highlight .kn,
+[data-theme="light"] .highlight .kp,
+[data-theme="light"] .highlight .kr,
+[data-theme="light"] .highlight .kt {
+  color: #d73a49 !important;
+  background: transparent !important;
+}
+
+[data-theme="light"] .highlight .s,
+[data-theme="light"] .highlight .s1,
+[data-theme="light"] .highlight .s2,
+[data-theme="light"] .highlight .se,
+[data-theme="light"] .highlight .sh,
+[data-theme="light"] .highlight .sx {
+  color: #0a3069 !important;
+  background: transparent !important;
+}
+
+[data-theme="light"] .highlight .n,
+[data-theme="light"] .highlight .na,
+[data-theme="light"] .highlight .nb,
+[data-theme="light"] .highlight .nc,
+[data-theme="light"] .highlight .nf,
+[data-theme="light"] .highlight .ni,
+[data-theme="light"] .highlight .nl,
+[data-theme="light"] .highlight .nn,
+[data-theme="light"] .highlight .no,
+[data-theme="light"] .highlight .nt,
+[data-theme="light"] .highlight .nv {
+  color: #6f42c1 !important;
+  background: transparent !important;
+}
+
+[data-theme="light"] .highlight .c,
+[data-theme="light"] .highlight .c1,
+[data-theme="light"] .highlight .cm,
+[data-theme="light"] .highlight .cp {
+  color: #6e7781 !important;
+  background: transparent !important;
+}
+
+[data-theme="light"] .highlight .mi,
+[data-theme="light"] .highlight .mf {
+  color: #0550ae !important;
+  background: transparent !important;
+}
+
+/* Theme toggle button */
+#theme-toggle {
+  background: transparent !important;
+  border: none !important;
+  cursor: pointer !important;
+  padding: 0 !important;
+  font-size: inherit !important;
+  color: var(--text-primary) !important;
+  transition: color 0.2s ease !important;
+}
+
+#theme-toggle:hover {
+  color: var(--accent-gold) !important;
+}
+
+/* Base overrides */
+html {
+  background-color: var(--bg-primary) !important;
+}
+
+body {
+  background-color: var(--bg-primary) !important;
+  color: var(--text-primary) !important;
+}
+
+/* Override tachyons bg-white class used in body */
+body.bg-white {
+  background-color: var(--bg-primary) !important;
+}
+
+/* ============================================
+   PHASE 2: Typography with Google Fonts
+   ============================================ */
+
+/* Import fonts - Space Grotesk for body, Smooch Sans for display, JetBrains Mono for code */
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=Smooch+Sans:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap');
+
+/* Body text */
+body {
+  font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif !important;
+}
+
 body article {
-  font-family: 'Domine', Georgia, Times, serif !important;
+  font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif !important;
+  color: var(--text-primary) !important;
 }
 
-/* Also update table captions to use Domine */
-table caption {
-  font-family: 'Domine', Georgia, Times, serif !important;
+/* Headings - Smooch Sans for display style */
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Smooch Sans', 'Space Grotesk', sans-serif !important;
+  color: var(--text-primary) !important;
+  font-weight: 600 !important;
 }
+
+/* Header meta line (date/categories) - not bold */
+#hdr h2.fw1 {
+  font-family: 'Space Grotesk', sans-serif !important;
+  font-weight: 100 !important;
+}
+
+/* Code elements */
+code, pre, .highlight, .listingblock pre, kbd, samp {
+  font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace !important;
+}
+
+/* Table captions */
+table caption {
+  font-family: 'Space Grotesk', sans-serif !important;
+  color: var(--text-secondary) !important;
+}
+
+/* ============================================
+   PHASE 3: Navigation & Header Styling
+   ============================================ */
+
+/* Navigation bar - only apply background outside header */
+nav.bg-black {
+  background-color: var(--bg-secondary) !important;
+}
+
+/* Nav inside header should be transparent (image shows through) */
+header nav.sans-serif {
+  background-color: transparent !important;
+}
+
+/* Nav links */
+nav a.near-white,
+nav a.link {
+  color: var(--text-primary) !important;
+  transition: color 0.2s ease !important;
+}
+
+nav a.near-white:hover,
+nav a.link:hover {
+  color: var(--accent-gold) !important;
+}
+
+/* Header background overlay */
+header.cover .bg-black-30 {
+  background-color: rgba(13, 17, 23, 0.85) !important;
+}
+
+/* Header title with gold glow effect */
+#hdr h1,
+#hdr .f2 {
+  color: var(--text-primary) !important;
+}
+
+/* Terminal title effect with gold glow */
+.terminal-title {
+  color: var(--accent-gold) !important;
+  text-shadow:
+    0 0 10px var(--accent-gold-glow),
+    0 0 20px var(--accent-gold-glow),
+    0 0 30px var(--accent-gold-glow) !important;
+}
+
+/* Terminal cursor */
+.terminal-cursor {
+  background-color: var(--accent-gold) !important;
+  box-shadow: 0 0 8px var(--accent-gold-glow) !important;
+}
+
+/* Header subtitle/meta */
+#hdr h2,
+#hdr .fw1 {
+  color: var(--text-secondary) !important;
+}
+
+/* Category links in header */
+#hdr a.category,
+#hdr a.near-white {
+  color: var(--text-primary) !important;
+}
+
+#hdr a.category:hover,
+#hdr a.near-white:hover {
+  color: var(--accent-gold) !important;
+}
+
+/* ============================================
+   PHASE 4: Content Styling
+   ============================================ */
+
+/* Main content area */
+main {
+  background-color: var(--bg-primary) !important;
+}
+
+/* Article */
+article.article {
+  background-color: var(--bg-primary) !important;
+  color: var(--text-primary) !important;
+}
+
+/* Paragraphs */
+article p {
+  color: var(--text-primary) !important;
+}
+
+/* Links - gold accent */
+a {
+  color: var(--accent-gold) !important;
+  transition: color 0.2s ease !important;
+}
+
+a:hover {
+  color: var(--accent-gold-bright) !important;
+}
+
+/* Links within article content */
+article a {
+  color: var(--accent-gold) !important;
+  text-decoration: underline !important;
+  text-decoration-color: var(--accent-gold-dim) !important;
+  text-underline-offset: 2px !important;
+}
+
+article a:hover {
+  color: var(--accent-gold-bright) !important;
+  text-decoration-color: var(--accent-gold-bright) !important;
+}
+
+/* Headline hash links */
+a.headline-hash {
+  color: var(--text-muted) !important;
+  text-decoration: none !important;
+  opacity: 0.5;
+  transition: opacity 0.2s ease !important;
+}
+
+a.headline-hash:hover {
+  color: var(--accent-gold) !important;
+  opacity: 1;
+}
+
+/* Code blocks - dark theme */
+pre,
+code,
+.highlight,
+.highlight pre,
+.listingblock pre {
+  background-color: var(--bg-code) !important;
+  color: var(--text-primary) !important;
+  border: 1px solid var(--border-default) !important;
+  border-radius: 6px !important;
+}
+
+/* Inline code */
+:not(pre) > code {
+  background-color: var(--bg-code) !important;
+  color: var(--accent-gold) !important;
+  padding: 0.2em 0.4em !important;
+  border-radius: 4px !important;
+  font-size: 0.9em !important;
+}
+
+/* Code block title/caption */
+.listingblock .title,
+.highlight .title {
+  color: var(--text-secondary) !important;
+  background-color: var(--bg-secondary) !important;
+}
+
+/* Blockquotes */
+blockquote {
+  background-color: var(--bg-secondary) !important;
+  border-left: 4px solid var(--accent-gold) !important;
+  color: var(--text-secondary) !important;
+  padding: 1rem !important;
+  margin: 1rem 0 !important;
+}
+
+blockquote p {
+  color: var(--text-secondary) !important;
+}
+
+/* Tables */
+table {
+  background-color: var(--bg-secondary) !important;
+  border-collapse: collapse !important;
+}
+
+table th {
+  background-color: var(--bg-card) !important;
+  color: var(--text-primary) !important;
+  border: 1px solid var(--border-default) !important;
+  padding: 0.75rem !important;
+}
+
+table td {
+  background-color: var(--bg-secondary) !important;
+  color: var(--text-primary) !important;
+  border: 1px solid var(--border-default) !important;
+  padding: 0.75rem !important;
+}
+
+table tr:hover td {
+  background-color: var(--bg-hover) !important;
+}
+
+/* HR/dividers */
+hr {
+  border-color: var(--border-default) !important;
+  border-top: 1px solid var(--border-default) !important;
+}
+
+/* Lists */
+ul, ol {
+  color: var(--text-primary) !important;
+}
+
+li {
+  color: var(--text-primary) !important;
+}
+
+/* Definition lists */
+dt {
+  color: var(--text-primary) !important;
+  font-weight: 600 !important;
+}
+
+dd {
+  color: var(--text-secondary) !important;
+}
+
+/* ============================================
+   PHASE 5: Post Cards with Gold Hover Effect
+   ============================================ */
+
+/* Post card containers */
+.post-card,
+.card,
+article.post,
+.summary,
+.list-item {
+  background-color: var(--bg-card) !important;
+  border: 1px solid var(--border-default) !important;
+  border-radius: 8px !important;
+  transition: all 0.3s ease !important;
+}
+
+.post-card:hover,
+.card:hover,
+article.post:hover,
+.summary:hover,
+.list-item:hover {
+  border-color: var(--accent-gold) !important;
+  box-shadow: var(--shadow-gold) !important;
+}
+
+/* Post card titles */
+.post-card h2,
+.post-card h3,
+.card h2,
+.card h3,
+.summary h2,
+.summary h3 {
+  color: var(--text-primary) !important;
+  transition: color 0.2s ease !important;
+}
+
+.post-card:hover h2,
+.post-card:hover h3,
+.card:hover h2,
+.card:hover h3 {
+  color: var(--accent-gold) !important;
+}
+
+/* Post card meta/dates */
+.post-card time,
+.post-card .meta,
+.card time,
+.summary time {
+  color: var(--text-secondary) !important;
+}
+
+/* Post card excerpts */
+.post-card p,
+.card p,
+.summary p {
+  color: var(--text-secondary) !important;
+}
+
+/* Retro cards specific styling */
+.retro-card {
+  background-color: var(--bg-card) !important;
+  border: 1px solid var(--border-default) !important;
+  transition: all 0.3s ease !important;
+}
+
+.retro-card:hover {
+  border-color: var(--accent-gold) !important;
+  box-shadow: var(--shadow-gold) !important;
+  transform: translateY(-2px) !important;
+}
+
+/* ============================================
+   PHASE 6: ToC Sidebar Dark Styling
+   ============================================ */
+
+/* ToC container */
+#toc,
+.toc,
+#TableOfContents,
+.toc-sidebar,
+aside.toc {
+  background-color: var(--bg-secondary) !important;
+  border: 1px solid var(--border-default) !important;
+  border-radius: 8px !important;
+}
+
+/* ToC title */
+#toc h2,
+.toc h2,
+.toc-title {
+  color: var(--text-primary) !important;
+  border-bottom: 1px solid var(--border-default) !important;
+}
+
+/* ToC links */
+#toc a,
+.toc a,
+#TableOfContents a {
+  color: var(--text-secondary) !important;
+  text-decoration: none !important;
+  transition: all 0.2s ease !important;
+}
+
+#toc a:hover,
+.toc a:hover,
+#TableOfContents a:hover {
+  color: var(--accent-gold) !important;
+}
+
+/* ToC active state */
+#toc a.active,
+.toc a.active,
+#TableOfContents a.active,
+#toc li.active > a,
+.toc li.active > a {
+  color: var(--accent-gold) !important;
+  font-weight: 600 !important;
+  border-left: 3px solid var(--accent-gold) !important;
+  padding-left: 0.5rem !important;
+}
+
+/* ToC list styling */
+#toc ul,
+.toc ul,
+#TableOfContents ul {
+  list-style: none !important;
+  padding-left: 1rem !important;
+}
+
+#toc li,
+.toc li,
+#TableOfContents li {
+  padding: 0.25rem 0 !important;
+}
+
+/* ============================================
+   PHASE 7: Comments Section (Giscus container)
+   ============================================ */
+
+/* Giscus container styling */
+.giscus,
+.giscus-frame {
+  background-color: var(--bg-secondary) !important;
+}
+
+/* Comments wrapper div */
+article > div[style*="background-color"] {
+  background-color: var(--bg-secondary) !important;
+  border-color: var(--accent-gold) !important;
+}
+
+/* ============================================
+   PHASE 8: Images, Videos & Media
+   ============================================ */
 
 /* Ensure proper spacing for video blocks and make them shrink-wrap to content */
 .videoblock {
@@ -28,6 +690,8 @@ table caption {
 .videoblock video {
   max-width: 100%;
   display: block;
+  border: 1px solid var(--border-default) !important;
+  border-radius: 6px !important;
 }
 
 /* Ensure proper spacing for image blocks and make them shrink-wrap to content */
@@ -40,20 +704,426 @@ table caption {
 .imageblock img {
   max-width: 100%;
   display: block;
+  border: 1px solid var(--border-default) !important;
+  border-radius: 6px !important;
+}
+
+/* All images in articles */
+article img {
+  border: 1px solid var(--border-default) !important;
+  border-radius: 6px !important;
 }
 
 /* Titles for both images and videos - render underneath with same styling */
 .videoblock .title,
 .imageblock .title {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif !important;
+  font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif !important;
   font-style: normal !important;
   font-weight: normal !important;
   text-align: center;
-  margin-top: 0.25rem;
+  margin-top: 0.5rem;
   margin-bottom: 0;
   padding: 0.25rem 0;
-  color: #888;
+  color: var(--text-secondary) !important;
   font-size: 0.85em;
   display: table-caption;
   caption-side: bottom;
+}
+
+/* Embedded content (iframes, embeds) */
+iframe,
+embed,
+object {
+  border: 1px solid var(--border-default) !important;
+  border-radius: 6px !important;
+}
+
+/* Figure captions */
+figcaption {
+  color: var(--text-secondary) !important;
+  font-size: 0.9em !important;
+  margin-top: 0.5rem !important;
+}
+
+/* ============================================
+   PHASE 8: Forms, Search & Footer
+   ============================================ */
+
+/* Form inputs */
+input,
+textarea,
+select {
+  background-color: var(--bg-secondary) !important;
+  color: var(--text-primary) !important;
+  border: 1px solid var(--border-default) !important;
+  border-radius: 6px !important;
+  padding: 0.5rem 1rem !important;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  border-color: var(--accent-gold) !important;
+  outline: none !important;
+  box-shadow: 0 0 0 2px var(--accent-gold-glow) !important;
+}
+
+input::placeholder,
+textarea::placeholder {
+  color: var(--text-muted) !important;
+}
+
+/* Search input specific */
+input[type="search"],
+.search-input {
+  background-color: var(--bg-secondary) !important;
+  color: var(--text-primary) !important;
+}
+
+/* Buttons */
+button,
+.button,
+input[type="submit"],
+input[type="button"] {
+  background-color: var(--accent-gold) !important;
+  color: var(--bg-primary) !important;
+  border: none !important;
+  border-radius: 6px !important;
+  padding: 0.5rem 1rem !important;
+  font-weight: 600 !important;
+  cursor: pointer !important;
+  transition: all 0.2s ease !important;
+}
+
+button:hover,
+.button:hover,
+input[type="submit"]:hover,
+input[type="button"]:hover {
+  background-color: var(--accent-gold-bright) !important;
+  box-shadow: var(--shadow-gold) !important;
+}
+
+/* Footer */
+footer {
+  background-color: var(--bg-secondary) !important;
+  border-top: 1px solid var(--border-default) !important;
+}
+
+footer.bg-black {
+  background-color: var(--bg-secondary) !important;
+}
+
+footer p,
+footer span,
+footer a {
+  color: var(--text-secondary) !important;
+}
+
+footer a:hover {
+  color: var(--accent-gold) !important;
+}
+
+/* ============================================
+   ADDITIONAL OVERRIDES
+   ============================================ */
+
+/* Override tachyons near-white text color */
+.near-white {
+  color: var(--text-primary) !important;
+}
+
+/* Override tachyons gray/dark colors */
+.gray, .dark-gray, .mid-gray {
+  color: var(--text-secondary) !important;
+}
+
+/* Override tachyons black text */
+.black {
+  color: var(--text-primary) !important;
+}
+
+/* Pagination */
+.pagination,
+.page-numbers {
+  background-color: var(--bg-secondary) !important;
+}
+
+.pagination a,
+.page-numbers a {
+  color: var(--text-primary) !important;
+  background-color: var(--bg-card) !important;
+  border: 1px solid var(--border-default) !important;
+}
+
+.pagination a:hover,
+.page-numbers a:hover {
+  color: var(--accent-gold) !important;
+  border-color: var(--accent-gold) !important;
+}
+
+.pagination .current,
+.page-numbers .current {
+  background-color: var(--accent-gold) !important;
+  color: var(--bg-primary) !important;
+}
+
+/* About section */
+.about,
+#about {
+  background-color: var(--bg-secondary) !important;
+  border: 1px solid var(--border-default) !important;
+  border-radius: 8px !important;
+}
+
+/* About the author - align image and text side by side */
+.about-the-author {
+  display: grid !important;
+  grid-template-columns: auto 1fr !important;
+  gap: 1rem !important;
+  align-items: center !important;
+}
+
+.about-the-author hr {
+  grid-column: 1 / -1 !important;
+  width: 100% !important;
+  margin: 0 0 0.5rem 0 !important;
+}
+
+.about-the-author p {
+  margin: 0 !important;
+}
+
+.about-the-author p img {
+  max-width: 100px !important;
+  height: auto !important;
+  border-radius: 8px !important;
+  display: block !important;
+}
+
+/* Categories/Tags */
+.tag,
+.category-tag,
+a.tag {
+  background-color: var(--bg-card) !important;
+  color: var(--text-secondary) !important;
+  border: 1px solid var(--border-default) !important;
+  border-radius: 4px !important;
+  padding: 0.25rem 0.5rem !important;
+  transition: all 0.2s ease !important;
+}
+
+.tag:hover,
+.category-tag:hover,
+a.tag:hover {
+  background-color: var(--bg-hover) !important;
+  color: var(--accent-gold) !important;
+  border-color: var(--accent-gold) !important;
+}
+
+/* Admonition/Note blocks */
+.admonition,
+.note,
+.warning,
+.tip,
+.important {
+  background-color: var(--bg-secondary) !important;
+  border-left: 4px solid var(--accent-gold) !important;
+  color: var(--text-primary) !important;
+}
+
+/* Selection highlight */
+::selection {
+  background-color: var(--accent-gold) !important;
+  color: var(--bg-primary) !important;
+}
+
+::-moz-selection {
+  background-color: var(--accent-gold) !important;
+  color: var(--bg-primary) !important;
+}
+
+/* Scrollbar styling for webkit browsers */
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--bg-secondary);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--border-default);
+  border-radius: 5px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted);
+}
+
+/* ============================================
+   RETRO CARDS - Override theme styles
+   ============================================ */
+
+.retro-card {
+  background: var(--bg-card) !important;
+  border: 1px solid var(--border-default) !important;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3) !important;
+}
+
+.retro-card:hover {
+  box-shadow: var(--shadow-gold) !important;
+  border-color: var(--accent-gold) !important;
+}
+
+.retro-card-inner {
+  background: var(--bg-card) !important;
+}
+
+.retro-card-meta {
+  color: var(--text-secondary) !important;
+  font-family: 'Space Grotesk', sans-serif !important;
+}
+
+.retro-card-title {
+  color: var(--text-primary) !important;
+  font-family: 'Smooch Sans', 'Space Grotesk', sans-serif !important;
+}
+
+.retro-card:hover .retro-card-title {
+  color: var(--accent-gold) !important;
+}
+
+.retro-card-summary {
+  color: var(--text-secondary) !important;
+}
+
+.retro-card-summary p {
+  color: var(--text-secondary) !important;
+}
+
+.retro-card-date {
+  background: rgba(13, 17, 23, 0.9) !important;
+  color: var(--text-primary) !important;
+  font-family: 'Space Grotesk', sans-serif !important;
+}
+
+.retro-card-summary a {
+  color: var(--accent-gold) !important;
+}
+
+.retro-card-summary a:hover {
+  color: var(--accent-gold-bright) !important;
+}
+
+/* Terminal title - gold glow version */
+.terminal-title {
+  font-family: 'JetBrains Mono', 'Courier New', monospace !important;
+  background: rgba(13, 17, 23, 0.95) !important;
+  color: var(--accent-gold) !important;
+  text-shadow:
+    0 0 10px var(--accent-gold-glow),
+    0 0 20px var(--accent-gold-glow),
+    0 0 30px var(--accent-gold-glow) !important;
+  border: 2px solid var(--border-default) !important;
+  box-shadow: inset 0 0 20px rgba(240, 180, 41, 0.1) !important;
+}
+
+.terminal-title::after {
+  background: rgba(240, 180, 41, 0.05) !important;
+}
+
+.terminal-cursor {
+  color: var(--accent-gold) !important;
+  border-bottom-color: var(--accent-gold) !important;
+}
+
+/* ============================================
+   TOC - Override theme toc.css styles
+   ============================================ */
+
+.docs-toc {
+  background-color: var(--bg-secondary) !important;
+  border-right: 1px solid var(--border-default) !important;
+  box-shadow: 1px 0 3px rgba(0, 0, 0, 0.2) !important;
+  scrollbar-color: var(--border-default) transparent !important;
+  font-family: 'Space Grotesk', sans-serif !important;
+}
+
+/* Mobile TOC drawer */
+@media (max-width: 1199.98px) {
+  .docs-toc {
+    border-left: 1px solid var(--border-default) !important;
+    box-shadow: -2px 0 8px rgba(0, 0, 0, 0.3) !important;
+  }
+
+  .toc-mobile-label {
+    background-color: rgba(240, 180, 41, 0.3) !important;
+    border: 2px solid var(--accent-gold-dim) !important;
+    color: var(--accent-gold) !important;
+    font-family: 'Space Grotesk', sans-serif !important;
+  }
+}
+
+.docs-toc::-webkit-scrollbar-thumb {
+  background-color: var(--border-default) !important;
+}
+
+.docs-toc-title {
+  color: var(--text-primary) !important;
+  border-bottom: 1px solid var(--border-default) !important;
+}
+
+.docs-toc nav > ul > li > a {
+  color: var(--text-secondary) !important;
+}
+
+.docs-toc nav > ul > li > ul {
+  border-left: 1px solid var(--border-default) !important;
+}
+
+.docs-toc nav > ul > li > ul > li > a {
+  color: var(--text-secondary) !important;
+}
+
+.docs-toc nav > ul > li > ul > li > ul {
+  border-left: 1px solid var(--border-muted) !important;
+}
+
+.docs-toc nav > ul > li > ul > li > ul > li > a {
+  color: var(--text-muted) !important;
+}
+
+.docs-toc nav > ul > li > ul > li > ul > li > ul {
+  border-left: 1px solid var(--border-muted) !important;
+}
+
+.docs-toc nav > ul > li > ul > li > ul > li > ul > li > a {
+  color: var(--text-muted) !important;
+}
+
+.docs-toc a {
+  color: var(--text-secondary) !important;
+}
+
+.docs-toc a:hover {
+  color: var(--accent-gold) !important;
+  background-color: rgba(240, 180, 41, 0.1) !important;
+}
+
+.docs-toc a.active {
+  color: var(--accent-gold) !important;
+  font-weight: 600 !important;
+}
+
+/* Print styles - keep readable */
+@media print {
+  body {
+    background-color: white !important;
+    color: black !important;
+  }
+
+  a {
+    color: black !important;
+  }
 }

--- a/themes/story/layouts/_default/baseof.html
+++ b/themes/story/layouts/_default/baseof.html
@@ -1,6 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
+		<script>
+		(function() {
+			var theme = localStorage.getItem('blog-theme');
+			if (!theme) theme = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+			if (theme === 'light') document.documentElement.setAttribute('data-theme', 'light');
+		})();
+		</script>
 		<meta http-equiv=X-Clacks-Overhead content="GNU Terry Pratchett">
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -63,6 +70,7 @@
 		<script src="{{ "js/story.js" | absURL }}"></script>
 		<script src="{{ "js/toc.js" | absURL }}"></script>
 		<script src="{{ "js/medium-mirror.js" | absURL }}"></script>
+		<script src="{{ "js/theme-toggle.js" | absURL }}" defer></script>
 
 	</head>
 	<body class="ma0 bg-white {{ with .Section }}section-{{ . }}{{ end }} page-kind-{{ .Kind }} is-page-{{ .IsPage }} {{ with .Site.Params.classes }}{{ range . }} {{ . }}{{ end }}{{ end }}{{ with .Params.classes }}{{ range . }} {{ . }}{{ end }}{{ end }}">
@@ -98,6 +106,9 @@
 						{{- end }}
 						<a class="link f5 ml2 dim near-white fas fa-rss-square" href="{{ "index.xml" | absURL }}" title="RSS Feed"></a>
 						<a class="link f5 ml2 dim near-white fas fa-search" href="{{ "search/" | absURL }}" role="search" title="Search"></a>
+						<button id="theme-toggle" class="link f5 ml2 dim near-white" title="Toggle theme">
+							<i class="fas fa-sun"></i>
+						</button>
 					</div>
 				</nav>
 
@@ -105,7 +116,7 @@
 					<h1 class="{{ cond $hdr "near-white mt1-ns" "" }} f2 fw3 mb0 mt0 lh-title">
 						<span class="terminal-title">{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}<span class="terminal-cursor"></span></span>
 					</h1>
-					<h2 class="{{ cond $hdr "near-white mt3-l mb4-l" "" }} fw1 f6 f3-l measure-wide-l center lh-copy mt2 mb3">
+					<h2 class="{{ cond $hdr "near-white mt3-l mb2-l" "" }} fw1 f6 f3-l measure-wide-l center lh-copy mt2 mb1">
 						<!-- You can put a subtitle here in _index.md parameters, or it'll get
 						filled in with date and categories if it's a post -->
 						{{ if .IsPage }}
@@ -117,7 +128,6 @@
 									<a class="no-underline category {{ cond $hdr "near-white dim" "black hover-gray" }}" href="{{ $.Params.site }}">{{ . }}</a>
 								{{ end }}
 							{{ else }}
-								Published
 								<time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">
 									{{- .Date.Format "Jan 2, 2006" -}}
 								</time>

--- a/themes/story/layouts/_default/single.html
+++ b/themes/story/layouts/_default/single.html
@@ -5,22 +5,28 @@
 <article class="article">
 	{{ .Content | replaceRE "(<h[2-9] id=\"([^\"]+)\".+)(</h[2-9]+>)" "${1}&nbsp;<a class=\"headline-hash\" href=\"#${2}\">🔗</a> ${3}" | safeHTML }}
 	<hr>
-	<div style="background-color: rgba(204, 234, 255, 0.25); margin-bottom:50px;margin-top:50px;padding: 20px; border-width: 2px; border-style: solid; border-color: darkorange;">
+	<div style="background-color: var(--bg-secondary); margin-bottom:50px;margin-top:50px;padding: 20px; border-width: 2px; border-style: solid; border-color: var(--accent-gold); border-radius: 8px;">
 	<!-- giscus start -->
-		<script src="https://giscus.app/client.js"
-				data-repo="rmoff/rmoff-blog"
-				data-repo-id="MDEwOlJlcG9zaXRvcnkxNTE3NDg2MTE="
-				data-category="Announcements"
-				data-category-id="DIC_kwDOCQuAA84CvP5T"
-				data-mapping="pathname"
-				data-strict="1"
-				data-reactions-enabled="1"
-				data-emit-metadata="0"
-				data-input-position="bottom"
-				data-theme="light"
-				data-lang="en"
-				crossorigin="anonymous"
-				async>
+		<script>
+		(function() {
+			var theme = localStorage.getItem('blog-theme');
+			if (!theme) theme = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+			var giscusTheme = theme === 'light' ? 'light' : 'dark_dimmed';
+			document.write('<script src="https://giscus.app/client.js" ' +
+				'data-repo="rmoff/rmoff-blog" ' +
+				'data-repo-id="MDEwOlJlcG9zaXRvcnkxNTE3NDg2MTE=" ' +
+				'data-category="Announcements" ' +
+				'data-category-id="DIC_kwDOCQuAA84CvP5T" ' +
+				'data-mapping="pathname" ' +
+				'data-strict="1" ' +
+				'data-reactions-enabled="1" ' +
+				'data-emit-metadata="0" ' +
+				'data-input-position="bottom" ' +
+				'data-theme="' + giscusTheme + '" ' +
+				'data-lang="en" ' +
+				'crossorigin="anonymous" ' +
+				'async><\/script>');
+		})();
 		</script>
 		<!-- giscus end -->
 	</div>

--- a/themes/story/static/js/theme-toggle.js
+++ b/themes/story/static/js/theme-toggle.js
@@ -1,0 +1,125 @@
+(function() {
+  'use strict';
+
+  var STORAGE_KEY = 'blog-theme';
+  var LIGHT_THEME = 'light';
+  var DARK_THEME = 'dark';
+
+  function getStoredTheme() {
+    return localStorage.getItem(STORAGE_KEY);
+  }
+
+  function getSystemTheme() {
+    return window.matchMedia('(prefers-color-scheme: light)').matches ? LIGHT_THEME : DARK_THEME;
+  }
+
+  function getCurrentTheme() {
+    var stored = getStoredTheme();
+    if (stored) return stored;
+    return getSystemTheme();
+  }
+
+  function setTheme(theme) {
+    if (theme === LIGHT_THEME) {
+      document.documentElement.setAttribute('data-theme', LIGHT_THEME);
+    } else {
+      document.documentElement.removeAttribute('data-theme');
+    }
+    localStorage.setItem(STORAGE_KEY, theme);
+    updateToggleIcon(theme);
+    updateGiscusTheme(theme);
+    updateSyntaxHighlighting(theme);
+  }
+
+  function updateToggleIcon(theme) {
+    var toggle = document.getElementById('theme-toggle');
+    if (!toggle) return;
+    var icon = toggle.querySelector('i');
+    if (!icon) return;
+    // Show sun icon when in dark mode (to switch to light)
+    // Show moon icon when in light mode (to switch to dark)
+    if (theme === LIGHT_THEME) {
+      icon.className = 'fas fa-moon';
+    } else {
+      icon.className = 'fas fa-sun';
+    }
+  }
+
+  function updateGiscusTheme(theme) {
+    var giscusFrame = document.querySelector('iframe.giscus-frame');
+    if (giscusFrame) {
+      giscusFrame.contentWindow.postMessage(
+        { giscus: { setConfig: { theme: theme === LIGHT_THEME ? 'light' : 'dark_dimmed' } } },
+        'https://giscus.app'
+      );
+    }
+  }
+
+  // Monokai dark colors -> GitHub light colors mapping
+  var COLOR_MAP = {
+    '#f8f8f2': '#24292f', // light gray -> dark text
+    '#f92672': '#cf222e', // pink -> red
+    '#66d9ef': '#0550ae', // cyan -> blue
+    '#e6db74': '#0a3069', // yellow -> dark blue (strings)
+    '#ae81ff': '#0550ae', // purple -> blue (numbers)
+    '#a6e22e': '#116329', // green -> dark green
+    '#75715e': '#6e7781', // gray -> gray (comments)
+    '#fd971f': '#953800'  // orange -> brown
+  };
+
+  function updateSyntaxHighlighting(theme) {
+    var spans = document.querySelectorAll('pre span[style], code span[style], .highlight span[style], .listingblock span[style]');
+    spans.forEach(function(span) {
+      var style = span.getAttribute('style') || '';
+      if (theme === LIGHT_THEME) {
+        // Store original style if not already stored
+        if (!span.dataset.originalStyle) {
+          span.dataset.originalStyle = style;
+        }
+        // Remove background colors and remap text colors
+        var newStyle = style.replace(/background-color:\s*#[0-9a-fA-F]+;?/gi, 'background-color: transparent;');
+        Object.keys(COLOR_MAP).forEach(function(dark) {
+          var light = COLOR_MAP[dark];
+          newStyle = newStyle.replace(new RegExp('color:\\s*' + dark.replace('#', '#?'), 'gi'), 'color: ' + light);
+        });
+        span.setAttribute('style', newStyle);
+      } else {
+        // Restore original style
+        if (span.dataset.originalStyle) {
+          span.setAttribute('style', span.dataset.originalStyle);
+        }
+      }
+    });
+  }
+
+  function toggleTheme() {
+    var current = getCurrentTheme();
+    var newTheme = current === LIGHT_THEME ? DARK_THEME : LIGHT_THEME;
+    setTheme(newTheme);
+  }
+
+  function init() {
+    var theme = getCurrentTheme();
+    updateToggleIcon(theme);
+    updateSyntaxHighlighting(theme);
+
+    var toggle = document.getElementById('theme-toggle');
+    if (toggle) {
+      toggle.addEventListener('click', toggleTheme);
+    }
+
+    // Listen for system theme changes
+    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function(e) {
+      if (!getStoredTheme()) {
+        setTheme(e.matches ? LIGHT_THEME : DARK_THEME);
+      }
+    });
+  }
+
+  // Initialize when DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary
- Add theme toggle button (sun/moon icon) in the navigation bar after search icon
- Persist user theme preference to localStorage (`blog-theme` key)
- Respect system `prefers-color-scheme` on first visit
- Add light theme CSS variables with GitHub-inspired color palette
- Add flash prevention script in `<head>` to avoid wrong theme on page load
- Dynamically update Giscus comments theme when toggling
- Remap Monokai syntax highlighting colors via JavaScript for light mode readability
- Make header image full-bleed (nav is transparent over image in both modes)
- Reduce header vertical spacing and remove "Published" prefix from date line
- Fix about section layout with CSS Grid for proper image/text alignment
- Remove Bluesky icon from about section