### PR TITLE
Move AsciiDoc syntax highlighting attributes to global config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -71,6 +71,10 @@ markup:
       toc-placement: "auto"
       toclevels: "2"
       figure-caption!: ""
+      source-highlighter: rouge
+      icons: font
+      rouge-css: style
+      rouge-style: monokai
     safeMode: unsafe
     workingFolderCurrent: true
   defaultMarkdownHandler: goldmark

--- a/content/post/active-mq-explode.adoc
+++ b/content/post/active-mq-explode.adoc
@@ -13,10 +13,6 @@ categories:
 - ksqlDB
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 
 The ActiveMQ source connector creates a https://docs.confluent.io/kafka-connect-activemq-source/current/index.html#io-confluent-connect-jms-value[Struct holding the value] of the message from ActiveMQ (as well as its https://docs.confluent.io/kafka-connect-activemq-source/current/index.html#io-confluent-connect-jms-key[key]). This is as would be expected. However, you can encounter _challenges_ in working with the data if the ActiveMQ data of interest within the payload is complex. Things like converters and schemas can get really funky, really quick. 

--- a/content/post/ai-agents.adoc
+++ b/content/post/ai-agents.adoc
@@ -11,10 +11,6 @@ categories:
 - Stumbling into AI
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: monokai
 
 _A link:/categories/stumbling-into-ai[short series] of notes for myself as I learn more about the AI ecosystem as of Autumn [Fall] 2025._
 _The driver for all this is understanding more about Apache Flink's https://github.com/apache/flink-agents[*Flink Agents*] project, and Confluent's https://www.confluent.io/product/streaming-agents/[**Streaming Agents**]._

--- a/content/post/ai-mcp.adoc
+++ b/content/post/ai-mcp.adoc
@@ -12,10 +12,6 @@ categories:
 - Stumbling into AI
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: monokai
 
 _A link:/categories/stumbling-into-ai[short series] of notes for myself as I learn more about the AI ecosystem as of September 2025._
 _The driver for all this is understanding more about Apache Flink's https://github.com/apache/flink-agents[*Flink Agents*] project, and Confluent's https://www.confluent.io/product/streaming-agents/[**Streaming Agents**]._

--- a/content/post/ai-ml.adoc
+++ b/content/post/ai-ml.adoc
@@ -11,10 +11,6 @@ categories:
 - Stumbling into AI
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: monokai
 
 Having looked at link:/2025/09/04/stumbling-into-ai-part-1mcp/[MCP], link:/2025/09/08/stumbling-into-ai-part-2models/[Models], and link:/2025/09/12/stumbling-into-ai-part-3rag/[RAG], I realised that I've been mentally skirting around something that I don't really understand, so I'm going to expose myself to some ridicule here and try to understand better: what's the difference between AI and ML? Aren't they just the same?
 

--- a/content/post/ai-models.adoc
+++ b/content/post/ai-models.adoc
@@ -11,10 +11,6 @@ categories:
 - Stumbling into AI
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: monokai
 
 _A link:/categories/stumbling-into-ai[short series] of notes for myself as I learn more about the AI ecosystem as of September 2025._
 _The driver for all this is understanding more about Apache Flink's https://github.com/apache/flink-agents[*Flink Agents*] project, and Confluent's https://www.confluent.io/product/streaming-agents/[**Streaming Agents**]._

--- a/content/post/ai-rag.adoc
+++ b/content/post/ai-rag.adoc
@@ -11,10 +11,6 @@ categories:
 - Stumbling into AI
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: monokai
 
 _A link:/categories/stumbling-into-ai[short series] of notes for myself as I learn more about the AI ecosystem as of September 2025._
 _The driver for all this is understanding more about Apache Flink's https://github.com/apache/flink-agents[*Flink Agents*] project, and Confluent's https://www.confluent.io/product/streaming-agents/[**Streaming Agents**]._

--- a/content/post/airtable_calendar.adoc
+++ b/content/post/airtable_calendar.adoc
@@ -9,10 +9,6 @@ categories:
 - Airtable
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 https://airtable.com[Airtable] is a rather wonderful tool. It powers link:/2022/08/31/inside-the-sausage-factory-how-we-built-the-program-for-current-2022/[the program creation backend process] for Kafka Summit and Current. It does, however, have a few frustrating limitations - often where it feels like a feature was built on a Friday afternoon and they didn't get chance to finish it before knocking off to head to the pub. 
 

--- a/content/post/alfred-app.adoc
+++ b/content/post/alfred-app.adoc
@@ -11,10 +11,6 @@ categories:
 - Alfred
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 I've used https://www.alfredapp.com/[Alfred] for years, and it's one of the first apps I'll install on a fresh Mac. It's like the Cmd-Space search integration that MacOS has, but *so much more than that*. Here's a few of the really powerful features that makes it the first app I'll reach for to install on any new Mac - and which it'll feel like I'm trying to work with one arm tied behind my back if I don't have :) 
 

--- a/content/post/antora-2.adoc
+++ b/content/post/antora-2.adoc
@@ -12,10 +12,6 @@ categories:
 - AWS Amplify
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 At https://decodable.co[Decodable] we migrated our docs platform onto https://antora.org/[Antora]. I wrote link:/2023/12/19/deploying-antora-with-github-actions-and-a-private-github-repo/[previously] about my escapades in getting cross-repository authentication working using https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#types-of-personal-access-tokens[Private Access Tokens] (PAT). These are fine for just a single user, but they're tied to that user, which isn't a good practice for deployment in this case.
 

--- a/content/post/apache-flink-cc-kafka.adoc
+++ b/content/post/apache-flink-cc-kafka.adoc
@@ -11,10 +11,6 @@ categories:
 - kcat
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: monokai
 
 This is a quick blog post to remind me how to connect Apache Flink to a Kafka topic on Confluent Cloud.
 You may wonder *why* you'd want to do this, given that https://www.confluent.io/en-gb/product/flink/[**Confluent Cloud for Apache Flink**] is a much easier way to run Flink SQL.

--- a/content/post/aws-pager.adoc
+++ b/content/post/aws-pager.adoc
@@ -10,10 +10,6 @@ categories:
 - pager
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 After a break from using AWS I had reason to reacquaint myself with it again today, and did so via the CLI. The https://aws.amazon.com/cli/[AWS CLI] is pretty intuitive and has a good helptext system, but one thing that kept frustrasting me was that after closing the help text, the screen cleared—so I couldn't copy the syntax out to use in my command!
 

--- a/content/post/bash_group_by.adoc
+++ b/content/post/bash_group_by.adoc
@@ -11,10 +11,6 @@ categories:
 - kcat (kafkacat)
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 _One of the fun things about working with data over the years is learning how to use the tools of the day—but also learning to fall back on the tools that are always there for you - and one of those is bash and its wonderful library of shell tools._
 

--- a/content/post/carpark-telegram-bot.adoc
+++ b/content/post/carpark-telegram-bot.adoc
@@ -14,10 +14,6 @@ categories:
 - Talks
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 I had the pleasure of presenting at https://dataengconf.com.au/[DataEngBytes] recently, and am delighted to share with you the *🗒️ slides, 👾 code, and 🎥 recording* of my ✨brand new talk✨: 
 

--- a/content/post/cc-flink-api.adoc
+++ b/content/post/cc-flink-api.adoc
@@ -11,10 +11,6 @@ categories:
 - API
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 
 https://www.confluent.io/en-gb/blog/serverless-flink-confluent-cloud-generally-available/[Confluent Cloud for Apache Flink] gives you access to run Flink workloads using a serverless platform on Confluent Cloud.

--- a/content/post/cc-webdev.adoc
+++ b/content/post/cc-webdev.adoc
@@ -11,10 +11,6 @@ categories:
 - Claude Code
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: monokai
 
 *_In which Claude and [A]I play at being webdevs._*
 *_For some reflections on the bigger picture of AI as a productivity tool for developers, have a look at link:/2026/01/27/reflections-of-a-developer-on-llms-in-january-2026/[the companion post to this one]._*

--- a/content/post/chrome-manage-search-engines.adoc
+++ b/content/post/chrome-manage-search-engines.adoc
@@ -10,10 +10,6 @@ categories:
 - Google Chrome
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 Google Chrome automagically adds sites that you visit which support searching to a list of custom search engines. For each one you can set a keyword which activates it, so based on the above list if I want to search Amazon I can just type `a` `<tab>` and then my search term
 

--- a/content/post/counting_kafka_messages.adoc
+++ b/content/post/counting_kafka_messages.adoc
@@ -10,10 +10,6 @@ categories:
 - ksqlDB
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 There's ways, and then there's ways, to count the number of records/events/messages in a Kafka topic. Most of them are potentially inaccurate, or inefficient, or both. Here's one that falls into the _potentially inefficient_ category, using `kafkacat` to read all the messages and pipe to `wc` which with the `-l` will tell you how many lines there are, and since each message is a line, how many messages you have in the Kafka topic: 
 

--- a/content/post/csv-into-kafka-dirty.adoc
+++ b/content/post/csv-into-kafka-dirty.adoc
@@ -15,10 +15,6 @@ categories:
 - hexdump
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 Whilst Apache Kafka is an event streaming platform designed for, well, _streams_ of events, it's perfectly valid to use it as a store of data which perhaps changes only occasionally (or even never). I'm thinking here of reference data (lookup data) that's used to enrich regular streams of events. 
 

--- a/content/post/csv-to-ccloud.adoc
+++ b/content/post/csv-to-ccloud.adoc
@@ -12,10 +12,6 @@ categories:
 - CSV
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 The https://www.confluent.io/hub/streamthoughts/kafka-connect-file-pulse?utm_source=rmoff&utm_medium=blog&utm_campaign=tm.devx_ch.rmoff_csv-to-ccloud.adoc&utm_term=rmoff-devx[FilePulse connector] from https://twitter.com/fhussonnois[Florian Hussonnois] is a really useful connector for Kafka Connect which enables you to ingest flat files including CSV, JSON, XML, etc into Kafka. You can read more it in https://streamthoughts.github.io/kafka-connect-file-pulse/docs/overview/filepulse/[its overview here]. Other connectors for ingested CSV data include https://www.confluent.io/hub/jcustenborder/kafka-connect-spooldir?utm_source=rmoff&utm_medium=blog&utm_campaign=tm.devx_ch.rmoff_csv-to-ccloud.adoc&utm_term=rmoff-devx[kafka-connect-spooldir] (which I link:/2020/06/17/loading-csv-data-into-kafka/[wrote about previously]), and https://www.confluent.io/hub/mmolimar/kafka-connect-fs?utm_source=rmoff&utm_medium=blog&utm_campaign=tm.devx_ch.rmoff_csv-to-ccloud.adoc&utm_term=rmoff-devx[kafka-connect-fs]. 
 

--- a/content/post/current22_5k.adoc
+++ b/content/post/current22_5k.adoc
@@ -12,10 +12,6 @@ categories:
 - 5k run/walk
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 At https://2022.currentevent.io/[Current 22] a few of us will be going for an early run on Tuesday morning. Everyone is very welcome! 
 

--- a/content/post/current24_5k.adoc
+++ b/content/post/current24_5k.adoc
@@ -12,10 +12,6 @@ categories:
 - 5k run/walk
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 At https://current.confluent.io/[Current 24] a few of us will be going for an early run (or walk) on Tuesday morning. Everyone is very welcome!
 

--- a/content/post/current25-london-5k.adoc
+++ b/content/post/current25-london-5k.adoc
@@ -12,10 +12,6 @@ categories:
 - 5k run/walk
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 **Another year, another Current—another 5k run/walk for anyone who'd like to join!**
 

--- a/content/post/current_program_building.adoc
+++ b/content/post/current_program_building.adoc
@@ -12,10 +12,6 @@ categories:
 - Conferences
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 If you've ever been to a conference, particularly as a speaker whose submitted a paper that may or may not have been accepted, you might wonder quite how conferences choose the talks that get accepted. 
 

--- a/content/post/da_from_home.adoc
+++ b/content/post/da_from_home.adoc
@@ -9,10 +9,6 @@ categories:
 - DevRel
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 I'm convinced that a developer advocate _can_ be effective remotely. As a profession, we've all spent two years figuring out how to do just that. Some of it worked out great. Some of it, less so. 
 

--- a/content/post/da_hanging_up_my_boarding_passes.adoc
+++ b/content/post/da_hanging_up_my_boarding_passes.adoc
@@ -9,10 +9,6 @@ categories:
 - DevRel
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 I recently started writing an abstract for a conference later this year and realised that I'm not even sure if I want to do it. Not the conference—it's a great one—but just the whole up on stage doing a talk thing. I can't work out if this is just nerves from the amount of time off the stage, or something more fundamental to deal with.
 

--- a/content/post/dataeng_arch.adoc
+++ b/content/post/dataeng_arch.adoc
@@ -11,10 +11,6 @@ categories:
 - Oracle
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 This is one of those _you had to be there_ moments. If you come into the world of data and analytics engineering today, ELT is just what it is and is pretty much universally understood. But if you've been around for …_waves hands_… longer than that, you might be confused by what people are calling ELT and ETL. Well, I was ✋. 
 

--- a/content/post/dataeng_dbt_current.adoc
+++ b/content/post/dataeng_dbt_current.adoc
@@ -12,10 +12,6 @@ categories:
 - Data Engineering
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 I started my dbt journey by link:/2022/10/20/data-engineering-in-2022-exploring-dbt-with-duckdb/[poking and pulling at the pre-built jaffle_shop demo running with DuckDB as its data store]. Now I want to see if I can put it to use myself to wrangle the session feedback data that came in from https://2022.currentevent.io/[Current 2022]. I've link:/2022/10/14/current-22-session-analysis-with-duckdb-and-jupyter-notebook/[analysed] this already, but it struck me that a particular part of it would benefit from some tidying up - and be a good excuse to see what it's like using dbt to do so. 
 

--- a/content/post/dataeng_elt.adoc
+++ b/content/post/dataeng_elt.adoc
@@ -13,10 +13,6 @@ categories:
 - Data Engineering
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 In link:/2022/09/14/stretching-my-legs-in-the-data-engineering-ecosystem-in-2022/[my quest] to bring myself up to date with where the data & analytics engineering world is at nowadays, I'm going to build on my exploration of the link:/2022/09/14/data-engineering-in-2022-storage-and-access/[storage and access] technologies and look at the tools we use for loading and transforming data. 
 

--- a/content/post/dataeng_intro.adoc
+++ b/content/post/dataeng_intro.adoc
@@ -9,10 +9,6 @@ categories:
 - Data Engineering
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 
 For the past 5.5 years I've been head-down in the exciting area of stream processing and events, and I realised recently that the world of data and analytics that I worked in up to 2017 which was changing significantly back then (Big Data, y'all!) has evolved and, dare I say it, matured somewhat - and I've not necessarily kept up with it. In this series of posts you can follow along as I start to reacquaint myself with where it's got to these days.

--- a/content/post/dataeng_query_and_xform.adoc
+++ b/content/post/dataeng_query_and_xform.adoc
@@ -9,10 +9,6 @@ categories:
 - Data Engineering
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 I previously looked at how we /2022/09/14/data-engineering-in-2022-storage-and-access/[store data] for analytics, with the interesting idea of data lakes with table formats (a.k.a. Data Lakehouse) considered. In this article I'll move to the next piece of the puzzle - what tools there are for working with that data. 
 

--- a/content/post/dataeng_resources.adoc
+++ b/content/post/dataeng_resources.adoc
@@ -9,10 +9,6 @@ categories:
 - Data Engineering
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 
 As I've been reading and exploring the current world of data engineering I've been adding links to my https://raindrop.io/rmoff/data-engineering-23335742[Raindrop.io collection], so check that out. In addition, below are some specific resources that I'd recommend. 

--- a/content/post/dataeng_storage_access.adoc
+++ b/content/post/dataeng_storage_access.adoc
@@ -14,10 +14,6 @@ categories:
 - LakeFS
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 In this article I look at where we store our analytical data, how we organise it, and how we enable access to it. I'm considering here potentially large volumes of data for access throughout an organisation. I'm not looking at data stores that are used for specific purposes (caches, low-latency analytics, graph etc).
 

--- a/content/post/deploy-ksqldb.adoc
+++ b/content/post/deploy-ksqldb.adoc
@@ -10,10 +10,6 @@ categories:
 - Confluent Cloud
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 There's https://github.com/spena/ksql/blob/7bc5875896c0206574e096c0ead808b5a87caa89/design-proposals/klip-42-schema-migrations-tool.md[a bunch of improvements] in the works for how ksqlDB handles code deployments and migrations. For now though, for deploying queries there's the option of using https://docs.ksqldb.io/en/latest/operate-and-deploy/installation/server-config/#non-interactive-headless-ksqldb-usage[headless mode] (which is limited to one query file and disables subsequent interactive work on the server from a CLI), manually running commands (yuck), or using the REST endpoint to deploy queries automagically. Here's an example of doing that. 
 

--- a/content/post/duckdb-etl.adoc
+++ b/content/post/duckdb-etl.adoc
@@ -12,10 +12,6 @@ categories:
 - Data Engineering
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 In this blog post I'm going to explore how as a data engineer in the field today I might go about putting together a rudimentary data pipeline.
 I'll take some operational data, and wrangle it into a form that makes it easily pliable for analytics work.

--- a/content/post/duckdb-ui-export.adoc
+++ b/content/post/duckdb-ui-export.adoc
@@ -9,10 +9,6 @@ categories:
 - DuckDB
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 DuckDB added a very cool https://duckdb.org/2025/03/12/duckdb-ui.html[UI] last week and link:/2025/03/14/kicking-the-tyres-on-the-new-duckdb-ui/[I've been using it] as my primary interface to DuckDB since.
 

--- a/content/post/duckdb-ui.adoc
+++ b/content/post/duckdb-ui.adoc
@@ -9,10 +9,6 @@ categories:
 - DuckDB
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 I wrote a couple of weeks ago about link:/2025/02/28/exploring-uk-environment-agency-data-in-duckdb-and-rill/[using DuckDB and Rill Data] to explore a new data source that I'm working with.
 I wanted to understand the data's structure and distribution of values, as well as how different entities related.

--- a/content/post/duckdb1.adoc
+++ b/content/post/duckdb1.adoc
@@ -9,10 +9,6 @@ categories:
 - DuckDB
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 I was exploring some new data, joining across multiple tables, and doing a simple `SELECT *` as I'd not worked out yet which columns I actually wanted.
 The issue was, the same field name existing in more than one table.

--- a/content/post/ducklake.adoc
+++ b/content/post/ducklake.adoc
@@ -10,10 +10,6 @@ categories:
 - Ducklake
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: monokai
 
 
 After a week's holiday ("vacation", for y'all in the US) without a glance at anything work-related, what joy to return and find that the DuckDB folk have been busy, not only with https://duckdb.org/2025/05/21/announcing-duckdb-130.html[the recent 1.3.0 DuckDB release], but also a brand new project called https://github.com/duckdb/ducklake[DuckLake].

--- a/content/post/embedding-content-in-asciidoc-in-hugo.adoc
+++ b/content/post/embedding-content-in-asciidoc-in-hugo.adoc
@@ -10,10 +10,6 @@ categories:
 - Asciidoc
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 I use https://gohugo.io/[Hugo] for my blog, hosted on GitHub pages. One of the reasons I'm really happy with it is that I can use Asciidoc to author my posts. I was writing a blog recently in which I wanted to include some code that's hosted on GitHub. I could have copied & pasted it into the blog but that would be lame! 
 

--- a/content/post/flink-iceberg-glue.adoc
+++ b/content/post/flink-iceberg-glue.adoc
@@ -11,10 +11,6 @@ categories:
 - Glue Data Catalog
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: monokai
 
 In this blog post I'll show how you can use Flink SQL to write to Iceberg on S3, storing metadata about the Iceberg tables in the https://docs.aws.amazon.com/glue/latest/dg/components-overview.html#data-catalog-intro[AWS Glue Data Catalog].
 First off, I'll walk through the dependencies and a simple smoke-test, and then put it into practice using it to write data from a Kafka topic to Iceberg.

--- a/content/post/flink-joins01.adoc
+++ b/content/post/flink-joins01.adoc
@@ -10,10 +10,6 @@ categories:
 - Apache Flink
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 
 There was a useful question on the https://flink.apache.org/what-is-flink/community/#slack[Apache Flink Slack] recently about joining data in Flink SQL:

--- a/content/post/flink-sql-explode.adoc
+++ b/content/post/flink-sql-explode.adoc
@@ -10,10 +10,6 @@ categories:
 - Apache Flink
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 Let's imagine we've got a source of data with a nested array of multiple values.
 The data is from an IoT device.

--- a/content/post/flink-sql-wrangling.adoc
+++ b/content/post/flink-sql-wrangling.adoc
@@ -11,10 +11,6 @@ categories:
 - Apache Flink for Confluent Cloud
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 The UK Government publishes a lot of its data as https://www.data.gov.uk/[open feeds].
 One that I keep coming back to is the https://environment.data.gov.uk/flood-monitoring/doc/reference[Environment Agency's flood-monitoring API] that gives access to an estate of sensors that provide information about data such as river levels and rainfall.

--- a/content/post/flinksql-changelogs.adoc
+++ b/content/post/flinksql-changelogs.adoc
@@ -11,10 +11,6 @@ categories:
 - Watermarks
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: monokai
 
 
 **SQL**. Three simple letters.

--- a/content/post/flinksql-time.adoc
+++ b/content/post/flinksql-time.adoc
@@ -11,10 +11,6 @@ categories:
 - Watermarks
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 Whether you're processing data in batch or as a stream, the concept of time is an important part of accurate processing logic.
 

--- a/content/post/hugo-errors.adoc
+++ b/content/post/hugo-errors.adoc
@@ -7,10 +7,6 @@ categories:
 - Hugo
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 After some changes on my Mac (maybe OS upgrade - not sure) my local install of Hugo stopped working. Recording the errors and steps I took (random jiggling to unbreak things) to help others in case it helps. 
 

--- a/content/post/hugo_ga_preview.adoc
+++ b/content/post/hugo_ga_preview.adoc
@@ -12,10 +12,6 @@ categories:
 - GitHub Actions
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 This blog is written in Asciidoc, built using Hugo, and hosted on GitHub Pages. I recently wanted to share the draft of a post I was writing with someone and ended up exporting a local preview to a PDF - not a great workflow! This blog post shows you how to create an automagic hosted preview of any draft content on Hugo using GitHub Actions.
 

--- a/content/post/iceberg-maintenance.adoc
+++ b/content/post/iceberg-maintenance.adoc
@@ -12,10 +12,6 @@ categories:
 - MinIO
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: monokai
 
 
 Iceberg nicely decouples storage from ingest and query (yay!).

--- a/content/post/il-2025-02.adoc
+++ b/content/post/il-2025-02.adoc
@@ -9,10 +9,6 @@ categories:
 - Interesting links
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 Here's a bunch of interesting links and articles about data that I've come across recently.
 

--- a/content/post/il-2025-03.adoc
+++ b/content/post/il-2025-03.adoc
@@ -9,10 +9,6 @@ categories:
 - Interesting Links
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 _The problem with publishing link:/2025/02/03/interesting-links-february-2025/[February's interesting links] at the beginning of the month and now getting around to publishing March's at the end is that I have nearly two months' worth of links to share 😅 So with no further ado, let's crack on._
 

--- a/content/post/jdbc-sink-primary-keys.adoc
+++ b/content/post/jdbc-sink-primary-keys.adoc
@@ -10,10 +10,6 @@ categories:
 - JDBC Sink
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 The Kafka Connect JDBC Sink can be used to stream data from a Kafka topic to a database such as Oracle, Postgres, MySQL, DB2, etc. 
 

--- a/content/post/jq-to-kafkacat-with-keys.adoc
+++ b/content/post/jq-to-kafkacat-with-keys.adoc
@@ -10,10 +10,6 @@ categories:
 - kcat (kafkacat)
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 
 One of my favourite hacks for getting data into Kafka is using kafkacat and `stdin`, often from `jq`. You can see this in action with link:/2020/03/11/streaming-wi-fi-trace-data-from-raspberry-pi-to-apache-kafka-with-confluent-cloud/[Wi-Fi data], link:/2020/01/21/monitoring-sonos-with-ksqldb-influxdb-and-grafana/[IoT data], and data from a link:/2018/05/10/quick-n-easy-population-of-realistic-test-data-into-kafka/[REST endpoint]. This is fine for getting values into a Kafka message - but Kafka messages are *key*/value, and being able to specify a key is can often be important. 

--- a/content/post/kafka-and-go-01.adoc
+++ b/content/post/kafka-and-go-01.adoc
@@ -12,10 +12,6 @@ categories:
 - Kafka Producer API
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 <!--more-->
 

--- a/content/post/kafka-and-go-02.adoc
+++ b/content/post/kafka-and-go-02.adoc
@@ -14,10 +14,6 @@ categories:
 - Type Assertion
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 
 I looked link:/2020/07/08/learning-golang-some-rough-notes-s02e01-my-first-kafka-go-producer/[last time] at the very bare basics of writing a Kafka producer using Go. It worked, but only with everything lined up and pointing the right way. There was no error handling of any sorts. Let's see about fixing this now. 

--- a/content/post/kafka-and-go-03.adoc
+++ b/content/post/kafka-and-go-03.adoc
@@ -12,10 +12,6 @@ categories:
 - Kafka Consumer API
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 Having written my first link:/2020/07/08/learning-golang-some-rough-notes-s02e01-my-first-kafka-go-producer/[Kafka producer in Go], and even link:/2020/07/10/learning-golang-some-rough-notes-s02e02-adding-error-handling-to-the-producer/[added error handling to it], the next step was to write a consumer. It follows closely the pattern of link:/2020/07/10/learning-golang-some-rough-notes-s02e02-adding-error-handling-to-the-producer/[Producer code I finished up with previously], using the channel-based approach for the https://docs.confluent.io/current/clients/confluent-kafka-go/index.html#Consumer[Consumer]:  
 

--- a/content/post/kafka-and-go-04.adoc
+++ b/content/post/kafka-and-go-04.adoc
@@ -12,10 +12,6 @@ categories:
 - Kafka Consumer API
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 Last time I looked at creating my link:/2020/07/14/learning-golang-some-rough-notes-s02e03-kafka-go-consumer-channel-based/[first Apache Kafka consumer in Go], which used the now-deprecated channel-based consumer. Whilst idiomatic for Go, it has some issues which mean that the function-based consumer is recommended for use instead. So let's go and use it!
 

--- a/content/post/kafka-and-go-05.adoc
+++ b/content/post/kafka-and-go-05.adoc
@@ -12,10 +12,6 @@ categories:
 - Kafka AdminClient API
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 Having ticked off the basics with an Apache Kafka link:/2020/07/10/learning-golang-some-rough-notes-s02e02-adding-error-handling-to-the-producer/[producer] and link:/2020/07/14/learning-golang-some-rough-notes-s02e03-kafka-go-consumer-channel-based/[consumer] in Go, let's now check out the AdminClient. This is useful for checking out metadata about the cluster, creating topics, and stuff like that. 
 

--- a/content/post/kafka-and-go-06.adoc
+++ b/content/post/kafka-and-go-06.adoc
@@ -13,10 +13,6 @@ categories:
 - Go routine
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 When I set out to link:/2020/06/25/learning-golang-some-rough-notes-s01e00/[learn Go] one of the aims I had in mind was to write a version of https://github.com/rmoff/kafka-listeners/blob/master/python/python_kafka_test_client.py[this little Python utility] which accompanies a blog I wrote recently about https://www.confluent.io/blog/kafka-client-cannot-connect-to-broker-on-aws-on-docker-etc[understanding and diagnosing problems with Kafka advertised listeners]. Having successfully got link:/2020/07/10/learning-golang-some-rough-notes-s02e02-adding-error-handling-to-the-producer/[Producer], link:/2020/07/14/learning-golang-some-rough-notes-s02e04-kafka-go-consumer-function-based/[Consumer], and link:/2020/07/15/learning-golang-some-rough-notes-s02e05-kafka-go-adminclient/[AdminClient] API examples working, it is now time to turn to that task. 
 

--- a/content/post/kafka-and-go-07.adoc
+++ b/content/post/kafka-and-go-07.adoc
@@ -11,10 +11,6 @@ categories:
 - Packages
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 So far I've been running all my code either in the https://tour.golang.org/[Go Tour sandbox], using https://play.golang.org/[Go Playground], or from a single file in VS Code. My explorations in the link:/2020/07/15/learning-golang-some-rough-notes-s02e06-putting-the-producer-in-a-function-and-handling-errors-in-a-go-routine/[previous article] ended up with a a source file that was starting to get a little bit unwieldily, so let's take a look at how that can be improved. 
 

--- a/content/post/kafka-and-go-08.adoc
+++ b/content/post/kafka-and-go-08.adoc
@@ -11,10 +11,6 @@ categories:
 - advertised.listeners
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 At the link:/2020/06/25/learning-golang-some-rough-notes-s01e00/[beginning of all this] my aim was to learn something new (Go), and use it to write a version of a utility that I'd previously https://github.com/rmoff/kafka-listeners/blob/master/python/python_kafka_test_client.py[hacked together in Python] that checks your Apache Kafka broker configuration for possible problems with the infamous `advertised.listeners` setting. Check out a blog that I wrote which explains _https://www.confluent.io/blog/kafka-client-cannot-connect-to-broker-on-aws-on-docker-etc[all about Apache Kafka and listener configuration]_.
 

--- a/content/post/kafka-and-go-09.adoc
+++ b/content/post/kafka-and-go-09.adoc
@@ -12,10 +12,6 @@ categories:
 - ksqlDB
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 
 The server sends `Transfer-Encoding: chunked` data, and you want to work with the data *as you get it*, instead of waiting for the server to finish, the EOF to fire, and _then_ process the data? 

--- a/content/post/kafka-connect-mysql-text-key.adoc
+++ b/content/post/kafka-connect-mysql-text-key.adoc
@@ -11,10 +11,6 @@ categories:
 - MySQL
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 I got the error `SQLSyntaxErrorException: BLOB/TEXT column 'MESSAGE_KEY' used in key specification without a key length` with https://docs.confluent.io/current/connect/kafka-connect-jdbc/sink-connector/index.html[Kafka Connect JDBC Sink connector] (v10.0.2) and MySQL (8.0.23)
 

--- a/content/post/kafka-data-profiling.adoc
+++ b/content/post/kafka-data-profiling.adoc
@@ -11,10 +11,6 @@ categories:
 - visidata
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 ksqlDB is a fantastically powerful tool for processing and analysing streams of data in Apache Kafka. But sometimes, you just want a quick way to profile the data in a topic in Kafka. I link:/2021/02/02/performing-a-group-by-on-data-in-bash/[wrote about this previously] with a convoluted (but effective) set of bash commands pipelined together to perform a `GROUP BY` on data. Then someone introduced me to `visidata`, which makes it all a lot quicker!
 

--- a/content/post/kafka-to-iceberg.adoc
+++ b/content/post/kafka-to-iceberg.adoc
@@ -13,10 +13,6 @@ categories:
 - Tableflow
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: monokai
 
 You've got data in https://www.youtube.com/watch?v=9CrlA0Wasvk[Apache Kafka].
 

--- a/content/post/kafka-xml-intro.adoc
+++ b/content/post/kafka-xml-intro.adoc
@@ -10,10 +10,6 @@ categories:
 - Kafka
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 XML has been around for 20+ years, and whilst other ways of serialising our data have gained popularity in more recent times (such as JSON, Avro, and Protobuf), XML is not going away soon. Part of that is down to technical reasons (clearly defined and documented schemas), and part of it is simply down to enterprise inertia - having adopted XML for systems in the last couple of decades, they're not going to be changing now just for some short-term fad. See also COBOL. 
 

--- a/content/post/kafka-xml-part01-hack.adoc
+++ b/content/post/kafka-xml-part01-hack.adoc
@@ -11,10 +11,6 @@ categories:
 - xq
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 _👉 link:/2020/10/01/ingesting-xml-data-into-kafka-introduction/[Ingesting XML data into Kafka - Introduction]_
 

--- a/content/post/kafka-xml-part02-smt.adoc
+++ b/content/post/kafka-xml-part02-smt.adoc
@@ -12,10 +12,6 @@ categories:
 - Single Message Transform
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 We previously looked at the background to link:/2020/10/01/ingesting-xml-data-into-kafka-introduction/[getting XML into Kafka], and potentially link:/2020/10/01/ingesting-xml-data-into-kafka-option-1-the-dirty-hack/[how &#91;not&#93; to do it]. Now let's look at the _proper_ way to build a streaming ingestion pipeline for XML into Kafka, using Kafka Connect. 
 

--- a/content/post/kafka-xml-part03-filepulse.adoc
+++ b/content/post/kafka-xml-part03-filepulse.adoc
@@ -12,10 +12,6 @@ categories:
 - FilePulse
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 👉 _link:/2020/10/01/ingesting-xml-data-into-kafka-introduction/[Ingesting XML data into Kafka - Introduction]_
 

--- a/content/post/kc-iceberg-glue.adoc
+++ b/content/post/kc-iceberg-glue.adoc
@@ -11,10 +11,6 @@ categories:
 - Kafka Connect
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: monokai
 
 Without wanting to mix my temperature metaphors, Iceberg is the new hawtness, and getting data into it from other places is a common task.
 I link:/2025/06/24/writing-to-apache-iceberg-on-s3-using-flink-sql-with-glue-catalog/[wrote previously about using Flink SQL to do this], and today I'm going to look at doing the same using Kafka Connect.

--- a/content/post/kc-worker-gcp.adoc
+++ b/content/post/kc-worker-gcp.adoc
@@ -12,10 +12,6 @@ categories:
 - Confluent Cloud
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 Confluent Cloud is not only a *fully*-managed Apache Kafka service, but also provides important additional pieces for building applications and pipelines including https://docs.confluent.io/cloud/current/connectors/index.html[managed connectors], https://docs.confluent.io/cloud/current/client-apps/schemas-manage.html[Schema Registry], and https://docs.confluent.io/cloud/current/ksqldb.html[ksqlDB]. Managed Connectors are run for you (hence, managed!) within Confluent Cloud - you just specify the technology to which you want to integrate in or out of Kafka and Confluent Cloud does the rest.
 

--- a/content/post/kcat-shows-wrong-topics.adoc
+++ b/content/post/kcat-shows-wrong-topics.adoc
@@ -10,10 +10,6 @@ categories:
 - Apache Kafka
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 Much as I love kcat (🤫 _it'll always be kafkacat to me_…), this morning I nearly fell out with it 👇 
 

--- a/content/post/kibana-open-sea-map.adoc
+++ b/content/post/kibana-open-sea-map.adoc
@@ -11,10 +11,6 @@ categories:
 - Open Data
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 Kibana's map functionality is a powerful way to visualise data that has a location element in it. I was recently working with data about ships at sea, and whilst the built in `Road map` is very good it doesn't show much maritime detail. 
 

--- a/content/post/ksl22_run.adoc
+++ b/content/post/ksl22_run.adoc
@@ -11,10 +11,6 @@ categories:
 - 5k run/walk
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 **https://www.myeventi.events/kafka22/gb/[Kafka Summit London] IS BACK**! After COVID spoiled everyone's fun and fundamentally screwed everything up for the past two years, I cannot wait to be back at an in-person conference. At the last Kafka Summit in the beforetimes (San Francisco, 2019) https://twitter.com/rmoff/status/1179047181891883008[some of us] got together for a link:/2019/09/23/kafka-summit-goldengate-bridge-run/walk/[run (or walk) across the GoldenGate bridge]. I can't promise quite the same views, but I thought it would be fun to do something similar when we meet in London later this month. 
 

--- a/content/post/ksl24-flink.adoc
+++ b/content/post/ksl24-flink.adoc
@@ -10,10 +10,6 @@ categories:
 - Apache Flink
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 
 This year Kafka Summit London includes a dedicated track for talks about Apache Flink. This reflects the continued rise of interest and use of Apache Flink in the streaming community, as well as the focus that Confluent (the hosts of Kafka Summit) has on it.

--- a/content/post/ksl24_run.adoc
+++ b/content/post/ksl24_run.adoc
@@ -11,10 +11,6 @@ categories:
 - 5k run/walk
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 At this year's Kafka Summit I'm planning to continue the tradition of going for a run (or walk) with anyone who'd like to join in. This started back at Kafka Summit San Francisco in 2019 https://twitter.com/rmoff/status/1179047181891883008[over the Golden Gate Bridge] and has continued since then. Whilst London's Docklands might not offer _quite_ the same experience it'll be fun nonetheless. 
 

--- a/content/post/ksqldb-howto.adoc
+++ b/content/post/ksqldb-howto.adoc
@@ -9,10 +9,6 @@ categories:
 - ksqlDB
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 Some people learn through doing - and for that there's a bunch of good ksqlDB tutorials https://docs.ksqldb.io/en/latest/tutorials/?utm_source=rmoff&utm_medium=blog&utm_campaign=tm.devx_ch.rmoff_ksqldb-howto&utm_term=rmoff-devx[here] and https://kafka-tutorials.confluent.io/?utm_source=rmoff&utm_medium=blog&utm_campaign=tm.devx_ch.rmoff_ksqldb-howto&utm_term=rmoff-devx[here]. Others may prefer to watch and listen first, before getting hands on. And for that, I humbly offer you this little series of videos all about ksqlDB. They're all based on a set of demo scripts that you can https://github.com/confluentinc/demo-scene/blob/master/introduction-to-ksqldb/demo_introduction_to_ksqldb_02.adoc[run for yourself and try out].
 

--- a/content/post/ksqldb-local-to-cloud.adoc
+++ b/content/post/ksqldb-local-to-cloud.adoc
@@ -10,10 +10,6 @@ categories:
 - Confluent Cloud
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 Using ksqlDB in https://www.confluent.io/confluent-cloud/tryfree?utm_source=rmoff&utm_medium=blog&utm_campaign=tm.devx_ch.rmoff_ksqldb-local-to-cloud&utm_term=rmoff-devx[Confluent Cloud] makes things a whole bunch easier because now you just get to build apps and streaming pipelines, instead of having to run and manage a bunch of infrastructure yourself. 
 

--- a/content/post/ksqldb-variable-struct-field.adoc
+++ b/content/post/ksqldb-variable-struct-field.adoc
@@ -9,10 +9,6 @@ categories:
 - ksqlDB
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 There was a https://stackoverflow.com/questions/64241285/kafka-topic-with-variable-nested-json-object-as-ksql-db-stream/64242383#64242383[good question on StackOverflow] recently in which someone was struggling to find the appropriate ksqlDB DDL to model a source topic in which there was a variable number of fields in a `STRUCT`.
 

--- a/content/post/ksqldb_tombstones.adoc
+++ b/content/post/ksqldb_tombstones.adoc
@@ -14,10 +14,6 @@ categories:
 - Compacted topic
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 
 As you may already realise, Kafka is not just a fancy message bus, or a pipe for big data. It's an event streaming platform! If this is news to you, I'll wait here whilst you https://www.confluent.io/learn/kafka-tutorial/[read this] or https://rmoff.dev/kafka101[watch this]… 

--- a/content/post/learn-from-their-mistakes.adoc
+++ b/content/post/learn-from-their-mistakes.adoc
@@ -11,10 +11,6 @@ categories:
 - Conferences
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 Building the program for any conference is not an easy task. There will always be a speaker disappointed that their talk didn't get in—or perhaps an audience who are disappointed that a particular talk _did_ get in. As the chair of the https://www.confluent.io/en-gb/blog/introducing-current-2022-program-committee/[program committee] for https://2022.currentevent.io/[Current 22] one of the things that I've found really useful in building out the program this time round are the comments that the program committee left against submissions as they reviewed them. 
 

--- a/content/post/li-carousel.adoc
+++ b/content/post/li-carousel.adoc
@@ -10,10 +10,6 @@ categories:
 - Blogging
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 TIP: tl;dr: Upload a PDF document in which each slide of the carousel is one page.
 

--- a/content/post/lightning_talks.adoc
+++ b/content/post/lightning_talks.adoc
@@ -12,10 +12,6 @@ categories:
 - Abstracts
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 (https://twitter.com/rmoff/status/1544257707049467905[src])
 

--- a/content/post/looking-forward.adoc
+++ b/content/post/looking-forward.adoc
@@ -12,10 +12,6 @@ categories:
 ---
 
 :figure-caption!:
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 As we enter December and 2022 draws to a close, so does a significant chapter in my working career—later this month I'll be leaving Confluent and onto pastures new. 
 

--- a/content/post/mac-tools.adoc
+++ b/content/post/mac-tools.adoc
@@ -10,10 +10,6 @@ categories:
 - Mac
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 
 This is the software counterpart to link:/2020/12/02/my-workstation-2020/[my previous article] in which I looked at my workstation's hardware setup. Some of these are unique or best-of-breed, others may have been https://www.economist.com/babbage/2012/07/13/youve-been-sherlocked[sherlocked] but I stick with them anyway :) 

--- a/content/post/minio-alt.adoc
+++ b/content/post/minio-alt.adoc
@@ -11,10 +11,6 @@ categories:
 - Apache Iceberg
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: monokai
 
 In late 2025 the company behind MinIO https://github.com/minio/object-browser/pull/3509[decided] https://github.com/minio/minio/issues/21647#issuecomment-3418675115[to] https://github.com/minio/minio/commit/27742d469462e1561c776f88ca7a1f26816d69e2[abandon] it to pursue other commercial interests.
 As well as upsetting a bunch of folk, it also put the cat amongst the pigeons of many software demos that relied on MinIO to emulate S3 storage locally, not to mention build pipelines that used it for validating S3 compatibility.

--- a/content/post/mq-channel-blocked.adoc
+++ b/content/post/mq-channel-blocked.adoc
@@ -8,10 +8,6 @@ categories:
 - Docker
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 
 Running IBM MQ in a Docker container and the client connecting to it was throwing repeated `Channel was blocked` errors. 

--- a/content/post/mssql-debezium-ksqldb.adoc
+++ b/content/post/mssql-debezium-ksqldb.adoc
@@ -13,10 +13,6 @@ categories:
 - Docker Compose
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 Prompted by https://stackoverflow.com/questions/63946368/how-to-use-the-debezium-sql-server-connector-with-ksqldb-embedded-connect[a question on StackOverflow] I thought I'd take a quick look at setting up https://ksqldb.io[ksqlDB] to ingest CDC events from Microsoft SQL Server using https://debezium.io/[Debezium]. Some of this is based on my previous article, link:/2019/11/20/streaming-data-from-sql-server-to-kafka-to-snowflake-with-kafka-connect/[Streaming data from SQL Server to Kafka to Snowflake ❄️ with Kafka Connect]. 
 

--- a/content/post/my-workstation-2020.adoc
+++ b/content/post/my-workstation-2020.adoc
@@ -8,10 +8,6 @@ categories:
 - Home office
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 _Is a blog even a blog nowadays if it doesn't include a "Here is my home office setup"?_
 

--- a/content/post/ngrok-dns.adoc
+++ b/content/post/ngrok-dns.adoc
@@ -10,10 +10,6 @@ categories:
 - dns
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 Let's not bury the lede: it was DNS. However, unlike the meme (_"It's not DNS, it's never DNS. It was DNS"_), I didn't even have an inkling that DNS might be the problem.
 

--- a/content/post/opml.adoc
+++ b/content/post/opml.adoc
@@ -13,10 +13,6 @@ categories:
 - Knowledge
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 I do my best to try and keep, if not abreast of, then at least aware of what's going on in the world of data. That includes RDBMS, Event streaming, stream processing, open source data projects, data engineering, object storage, and more. If you're interested in the same, then you might find this blog useful, because I'm sharing my sources :)
 

--- a/content/post/raycast02.adoc
+++ b/content/post/raycast02.adoc
@@ -11,10 +11,6 @@ categories:
 - Productivity
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: monokai
 
 > "What are the must-have apps to install on my new Mac?"…
 > "Which tool makes you the most productive?"…

--- a/content/post/reddit-graph.adoc
+++ b/content/post/reddit-graph.adoc
@@ -9,10 +9,6 @@ categories:
 - Reddit
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: monokai
 
 Reddit is one of the longer-standing platforms on the internet, bringing together folk to discuss, rant, grumble, and troll others on all sorts of topics, from https://old.reddit.com/r/apachekafka/[Kafka] to https://old.reddit.com/r/dataengineering/[data engineering] to https://old.reddit.com/r/flashlight/[nerding out over really bright torches] to https://old.reddit.com/r/britishproblems/[grumbling about the state of the country]—and a whole lot more.
 

--- a/content/post/reddit.adoc
+++ b/content/post/reddit.adoc
@@ -10,10 +10,6 @@ categories:
 - Reddit
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: monokai
 
 LLMs are _rapidly_ changing how we use the internet.
 Remember just a few years ago when you'd search for something on Google and _scroll_ through the results like some kind of Neanderthal?

--- a/content/post/restapi_to_kafka.adoc
+++ b/content/post/restapi_to_kafka.adoc
@@ -11,10 +11,6 @@ categories:
 - ksqlDB
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 
 ----

--- a/content/post/scheduling-hugo-builds-on-githubpages.adoc
+++ b/content/post/scheduling-hugo-builds-on-githubpages.adoc
@@ -12,10 +12,6 @@ categories:
 - GitHub Actions
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 Over the years I've used various blogging platforms; after a brief dalliance with Blogger I started for real with the near-inevitable Wordpress.com. From there I decided it would be fun to self-host using Ghost, and then almost link:/2018/12/17/moving-from-ghost-to-hugo/[exactly two years ago to the day] decided it definitely was not fun to spend time patching and upgrading my blog platform instead of writing blog articles, so headed over to my current platform of choice: Hugo hosted on GitHub pages. This has worked extremely well for me during that time, doing everything I want from it until recently. 
 

--- a/content/post/sdh.adoc
+++ b/content/post/sdh.adoc
@@ -10,10 +10,6 @@ categories:
 - DNS
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 A friend messaged me late last night with the scary news that Google had emailed him about a ton of spammy subdomains on his own domain. 
 

--- a/content/post/siai-jan26.adoc
+++ b/content/post/siai-jan26.adoc
@@ -11,10 +11,6 @@ categories:
 - Claude Code
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: monokai
 
 Funnily enough, Charles Dickens was talking about late 18th century Europe rather than the state of AI and LLMs in 2026, but here goes:
 

--- a/content/post/smt-wrapup.adoc
+++ b/content/post/smt-wrapup.adoc
@@ -11,10 +11,6 @@ categories:
 - TwelveDaysOfSMT
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 https://cwiki.apache.org/confluence/display/KAFKA/KIP-66%3A+Single+Message+Transforms+for+Kafka+Connect[KIP-66] was added in Apache Kafka 0.10.2 and brought new functionality called *Single Message Transforms* (SMT). Using SMT you can modify the data and its characteristics as it passes through Kafka Connect pipeline, without needing additional stream processors. For things like manipulating fields, changing topic names, conditionally dropping messages, and more, SMT are a perfect solution. If you get to things like aggregation, joining streams, and lookups then SMT may not be the best for you and you should head over to Kafka Streams or ksqlDB instead. 
 

--- a/content/post/smt10_replace.adoc
+++ b/content/post/smt10_replace.adoc
@@ -11,10 +11,6 @@ categories:
 - TwelveDaysOfSMT
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 The https://docs.confluent.io/platform/current/connect/transforms/replacefield.html[`ReplaceField`] Single Message Transform has three modes of operation on fields of data passing through Kafka Connect:
 

--- a/content/post/smt11_filter.adoc
+++ b/content/post/smt11_filter.adoc
@@ -11,10 +11,6 @@ categories:
 - TwelveDaysOfSMT
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 Apache Kafka 2.6 included https://cwiki.apache.org/confluence/display/KAFKA/KIP-585%3A+Filter+and+Conditional+SMTs[KIP-585] which adds support for defining predicates against which transforms are conditionally executed, as well as a https://docs.confluent.io/platform/current/connect/transforms/filter-ak.html[`Filter`] Single Message Transform to drop messages - which in combination means that you can conditionally drop messages. 
 

--- a/content/post/smt12_community.adoc
+++ b/content/post/smt12_community.adoc
@@ -11,10 +11,6 @@ categories:
 - TwelveDaysOfSMT
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 Apache Kafka ships with https://kafka.apache.org/documentation/#connect_included_transformation[many Single Message Transformations (SMT) included] - but the great thing about it being an https://kafka.apache.org/26/javadoc/org/apache/kafka/connect/transforms/Transformation.html[open API] is that people can, and do, write their own transformations. Many of these are shared with the wider community, and in this final installment of the series I'm going to look at some of the transformations written by Jeremy Custenborder and available in https://jcustenborder.github.io/kafka-connect-documentation/projects/kafka-connect-transform-common[`kafka-connect-transform-common`] which can be https://www.confluent.io/hub/jcustenborder/kafka-connect-transform-common[downloaded and installed from Confluent Hub] (or built from https://github.com/jcustenborder/kafka-connect-transform-common[source], if you like that kind of thing). Also check out the XML transformation by the same author, which link:/2020/10/01/ingesting-xml-data-into-kafka-option-2-kafka-connect-plus-single-message-transform/[I've written about previously]. 
 

--- a/content/post/smt1_insertfield_ts.adoc
+++ b/content/post/smt1_insertfield_ts.adoc
@@ -11,10 +11,6 @@ categories:
 - TwelveDaysOfSMT
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 You can use the https://docs.confluent.io/platform/current/connect/transforms/insertfield.html[`InsertField`] Single Message Transform (SMT) to add the message timestamp into each message that Kafka Connect sends to a sink. 
 

--- a/content/post/smt2_valuetokey.adoc
+++ b/content/post/smt2_valuetokey.adoc
@@ -11,10 +11,6 @@ categories:
 - TwelveDaysOfSMT
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 Setting the key of a Kafka message is important as it ensures correct logical processing when consumed across multiple partitions, as well as being a requirement when joining to messages in other topics. When using Kafka Connect the connector may already set the key, which is great. If not, you can use these two Single Message Transforms (SMT) to set it as part of the pipeline based on a field in the value part of the message. 
 

--- a/content/post/smt3_flatten.adoc
+++ b/content/post/smt3_flatten.adoc
@@ -11,10 +11,6 @@ categories:
 - TwelveDaysOfSMT
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 The https://docs.confluent.io/platform/current/connect/transforms/flatten.html[`Flatten`] Single Message Transform (SMT) is useful when you need to collapse a nested message down to a flat structure. 
 

--- a/content/post/smt4_regex.adoc
+++ b/content/post/smt4_regex.adoc
@@ -11,10 +11,6 @@ categories:
 - TwelveDaysOfSMT
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 If you want to change the topic name to which a source connector writes, or object name that's created on a target by a sink connector, the https://docs.confluent.io/platform/current/connect/transforms/regexrouter.html[`RegExRouter`] is exactly what you need. 
 

--- a/content/post/smt5_mask.adoc
+++ b/content/post/smt5_mask.adoc
@@ -11,10 +11,6 @@ categories:
 - TwelveDaysOfSMT
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 If you want to mask fields of data as you ingest from a source into Kafka, or write to a sink from Kafka with Kafka Connect, the https://docs.confluent.io/platform/current/connect/transforms/maskfield.html[`MaskField`] Single Message Transform is perfect for you. It retains the fields whilst replacing its value. 
 

--- a/content/post/smt6_insertfield2.adoc
+++ b/content/post/smt6_insertfield2.adoc
@@ -11,10 +11,6 @@ categories:
 - TwelveDaysOfSMT
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 We kicked off this series by seeing on link:/2020/12/08/twelve-days-of-smt-day-1-insertfield-timestamp/[day 1] how to use https://docs.confluent.io/platform/current/connect/transforms/insertfield.html[`InsertField`] to add in the timestamp to a message passing through the Kafka Connect sink connector. Today we'll see how to use the same Single Message Transform to add in a static field value, as well as the name of the Kafka topic, partition, and offset from which the message has been read. 
 

--- a/content/post/smt7_timestamprouter.adoc
+++ b/content/post/smt7_timestamprouter.adoc
@@ -11,10 +11,6 @@ categories:
 - TwelveDaysOfSMT
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 Just like the link:/2020/12/11/twelve-days-of-smt-day-4-regexrouter/[`RegExRouter`], the https://docs.confluent.io/platform/current/connect/transforms/timestamprouter.html[`TimeStampRouter`] can be used to modify the topic name of messages as they pass through Kafka Connect. Since the topic name is usually the basis for the naming of the object to which messages are written in a sink connector, this is a great way to achieve time-based partitioning of those objects if required. For example, instead of streaming messages from Kafka to an Elasticsearch index called `cars`, they can be routed to monthly indices e.g. `cars_2020-10`, `cars_2020-11`, `cars_2020-12`, etc. 
 

--- a/content/post/smt8_timestampconverter.adoc
+++ b/content/post/smt8_timestampconverter.adoc
@@ -11,10 +11,6 @@ categories:
 - TwelveDaysOfSMT
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 The https://docs.confluent.io/platform/current/connect/transforms/timestampconverter.html[`TimestampConverter`] Single Message Transform lets you work with timestamp fields in Kafka messages. You can convert a string into a native https://kafka.apache.org/26/javadoc/org/apache/kafka/connect/data/Timestamp.html[Timestamp] type (or https://kafka.apache.org/26/javadoc/org/apache/kafka/connect/data/Date.html[Date] or https://kafka.apache.org/26/javadoc/org/apache/kafka/connect/data/Time.html[Time]), as well as Unix epoch - and the same in reverse too. 
 

--- a/content/post/smt9_cast.adoc
+++ b/content/post/smt9_cast.adoc
@@ -11,10 +11,6 @@ categories:
 - TwelveDaysOfSMT
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 The https://docs.confluent.io/platform/current/connect/transforms/cast.html[`Cast`] Single Message Transform lets you change the data type of fields in a Kafka message, supporting numerics, string, and boolean. 
 

--- a/content/post/streaming-agents.adoc
+++ b/content/post/streaming-agents.adoc
@@ -14,10 +14,6 @@ categories:
 - MCP
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: monokai
 
 Ever tried to hammer a nail in with a potato?
 

--- a/content/post/streaming_kafka_geopoint_elasticsearch.adoc
+++ b/content/post/streaming_kafka_geopoint_elasticsearch.adoc
@@ -14,10 +14,6 @@ aliases:
 - "/2018/10/05/streaming-geopoint-data-from-kafka-to-elasticsearch/"
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 
 Streaming data from Kafka to Elasticsearch is easy with Kafka Connect - you can see how in this https://rmoff.dev/kafka-elasticsearch[tutorial] and https://rmoff.dev/kafka-elasticsearch-video[video]. 

--- a/content/post/telegram_bad_request.adoc
+++ b/content/post/telegram_bad_request.adoc
@@ -8,10 +8,6 @@ categories:
 ---
 
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 A tiny snippet since I wasted 10 minutes going around the houses on this one… 
 

--- a/content/post/topic-creation-config-override.adoc
+++ b/content/post/topic-creation-config-override.adoc
@@ -9,10 +9,6 @@ categories:
 - Kafka Connect
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 When Kafka Connect ingests data from a source system into Kafka it writes it to a topic. If you have set `auto.create.topics.enable = true` on your broker then the topic will be created when written to. If `auto.create.topics.enable = false` (as it is on Confluent Cloud and many self-managed environments, for good reasons) then you can tell Kafka Connect to create those topics first. _This was added in Apache Kafka 2.6 (Confluent Platform 6.0) - prior to that you had to manually create the topics yourself otherwise the connector would fail._
 

--- a/content/post/using-tcpdump-with-docker.adoc
+++ b/content/post/using-tcpdump-with-docker.adoc
@@ -8,7 +8,6 @@ categories:
 - tcpdump
 ---
 
-:source-highlighter: rouge
 
 = Using tcpdump with Docker
 

--- a/content/post/vale-asciidoc-disable.adoc
+++ b/content/post/vale-asciidoc-disable.adoc
@@ -10,10 +10,6 @@ categories:
 - vale
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: github
 
 I'm a *HUGE* fan of Docs as Code in general, and specifically tools like https://vale.sh[Vale] that lint your prose for adherence to style rule.
 

--- a/tests/performance.spec.ts
+++ b/tests/performance.spec.ts
@@ -167,3 +167,29 @@ test.describe('Navigation Consistency', () => {
     await expect(page.locator('.retro-card').first()).toBeVisible({ timeout: 5000 });
   });
 });
+
+test.describe('Syntax Highlighting', () => {
+  test('code blocks use monokai theme', async ({ page }) => {
+    // Page with known code blocks
+    await page.goto('http://localhost:1313/2025/03/25/confluent-cloud-for-apache-flink-exploring-the-api/');
+
+    // Check that code blocks have monokai styling (dark background #49483e)
+    const codeBlock = page.locator('pre.rouge.highlight').first();
+    await expect(codeBlock).toBeVisible();
+
+    const bgColor = await codeBlock.evaluate(el => getComputedStyle(el).backgroundColor);
+    // Monokai background is #49483e which is rgb(73, 72, 62)
+    expect(bgColor).toBe('rgb(73, 72, 62)');
+  });
+
+  test('admonition blocks use font icons', async ({ page }) => {
+    await page.goto('http://localhost:1313/2025/03/25/confluent-cloud-for-apache-flink-exploring-the-api/');
+
+    // Check for admonition with font icon
+    const admonition = page.locator('.admonitionblock.tip').first();
+    await expect(admonition).toBeVisible();
+
+    const icon = admonition.locator('.icon i.fa');
+    await expect(icon).toBeVisible();
+  });
+});

--- a/themes/story/archetypes/default.adoc
+++ b/themes/story/archetypes/default.adoc
@@ -9,9 +9,5 @@ categories:
 - Uncategorized
 ---
 
-:source-highlighter: rouge
-:icons: font
-:rouge-css: style
-:rouge-style: monokai
 
 <!--more-->


### PR DESCRIPTION
Consolidates source-highlighter, icons, rouge-css, and rouge-style
attributes from 117 individual posts into config.yaml. This ensures
consistent monokai theme across all posts and simplifies the archetype
template for new posts.

Adds Playwright tests to verify syntax highlighting and font icons.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
