### PR TITLE
Fix mobile/tablet horizontal overflow from stacked sidebar (#335 regression)

### DIFF
--- a/static/css/redesign.css
+++ b/static/css/redesign.css
@@ -2127,8 +2127,12 @@ h4:hover .headline-hash {
 
 /* --- Responsive: Tablet --- */
 @media (max-width: 1024px) {
+  /* minmax(0, 1fr) (not plain 1fr) so the single column can shrink below its
+     content's min-content width. The stacked .sidebar contains nowrap Popular
+     posts titles; with a plain 1fr track those would force the whole grid wider
+     than the viewport instead of being truncated with an ellipsis. */
   .layout-with-sidebar {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   /* Stack the sidebar below the post list rather than hiding it, so the

--- a/tests/mobile.spec.ts
+++ b/tests/mobile.spec.ts
@@ -1,6 +1,14 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 const mobileViewport = { width: 375, height: 812 };
+
+// Viewports for the overflow checks. Tablet (768px) matters because the
+// `html, body { overflow-x: hidden }` safety net only kicks in at <=640px, so
+// above that any over-wide content produces a genuinely scrollable, broken page.
+const overflowViewports = [
+  { name: 'mobile', width: 375, height: 812 },
+  { name: 'tablet', width: 768, height: 1024 },
+];
 
 const pages = [
   { name: 'homepage', url: '/' },
@@ -10,26 +18,49 @@ const pages = [
   { name: 'category-term', url: '/categories/apache-kafka/' },
 ];
 
+// The Popular posts widget is injected asynchronously by top-posts.js. Its
+// titles are `white-space: nowrap`, so they are exactly the content that can
+// blow out the layout — the overflow checks are only meaningful once it has
+// rendered. If the widget is present on the page, fail loudly when it never
+// populates rather than silently testing an empty (and therefore narrow)
+// sidebar, which is how the mobile overflow regression slipped through.
+async function waitForPopularPosts(p: Page) {
+  const widgetCount = await p.locator('.top-posts').count();
+  if (widgetCount === 0) return;
+  await expect(
+    p.locator('.top-posts-list a').first(),
+    'Popular posts widget present but never populated — overflow check would be a false pass',
+  ).toBeVisible({ timeout: 10000 });
+}
+
 for (const page of pages) {
-  test(`mobile: no horizontal overflow on ${page.name}`, async ({ browser }) => {
-    const context = await browser.newContext({ viewport: mobileViewport });
-    const p = await context.newPage();
-    await p.goto(`http://localhost:1313${page.url}`, { waitUntil: 'networkidle' });
-    await p.waitForTimeout(1000);
+  for (const vp of overflowViewports) {
+    test(`${vp.name}: no horizontal overflow on ${page.name}`, async ({ browser }) => {
+      const context = await browser.newContext({ viewport: { width: vp.width, height: vp.height } });
+      const p = await context.newPage();
+      await p.goto(`http://localhost:1313${page.url}`, { waitUntil: 'networkidle' });
+      await waitForPopularPosts(p);
 
-    // Check that body doesn't have horizontal overflow
-    const bodyScrollWidth = await p.evaluate(() => document.body.scrollWidth);
-    const windowWidth = await p.evaluate(() => window.innerWidth);
-    expect(bodyScrollWidth, `${page.name}: body scrollWidth (${bodyScrollWidth}) should not exceed viewport width (${windowWidth})`).toBeLessThanOrEqual(windowWidth + 1);
+      // Check that the page doesn't have horizontal overflow. We check the
+      // documentElement too: below 640px `body { overflow-x: hidden }` clamps
+      // body.scrollWidth, so body alone can mask real overflow.
+      const { bodyScrollWidth, docScrollWidth, windowWidth } = await p.evaluate(() => ({
+        bodyScrollWidth: document.body.scrollWidth,
+        docScrollWidth: document.documentElement.scrollWidth,
+        windowWidth: window.innerWidth,
+      }));
+      expect(bodyScrollWidth, `${page.name} @${vp.width}px: body scrollWidth (${bodyScrollWidth}) should not exceed viewport width (${windowWidth})`).toBeLessThanOrEqual(windowWidth + 1);
+      expect(docScrollWidth, `${page.name} @${vp.width}px: documentElement scrollWidth (${docScrollWidth}) should not exceed viewport width (${windowWidth})`).toBeLessThanOrEqual(windowWidth + 1);
 
-    await context.close();
-  });
+      await context.close();
+    });
+  }
 
   test(`mobile: text is readable on ${page.name}`, async ({ browser }) => {
     const context = await browser.newContext({ viewport: mobileViewport });
     const p = await context.newPage();
     await p.goto(`http://localhost:1313${page.url}`, { waitUntil: 'networkidle' });
-    await p.waitForTimeout(1000);
+    await waitForPopularPosts(p);
 
     // Check that the main content area doesn't have elements clipped off-screen
     // (skip elements inside scrollable containers - those are intentionally scrollable)


### PR DESCRIPTION
## What

On phones and tablets the homepage and list pages render badly — the entire page is shifted right and content is clipped off the right edge.

![bug](https://github.com/user-attachments/assets/placeholder)

## Root cause

`.layout-with-sidebar` collapses to a single `grid-template-columns: 1fr` column below 1024px. A bare `1fr` track is `minmax(auto, 1fr)` and **cannot shrink below its content's min-content width**.

The stacked sidebar's Popular-posts titles use `white-space: nowrap`, so each title's min-content width is the *full untruncated string* (e.g. "AI Slop is Killing Online Communities"). That forced the shared grid track to ~499px — and since every grid item shares the track, the featured post, post list and sidebar all became 499px wide on a 375px screen.

The fix uses `minmax(0, 1fr)` so the track can shrink to the viewport. The `text-overflow: ellipsis` already on the titles then truncates them as intended.

## When it was introduced

- **Latent condition:** #333 (popular-links) added `white-space: nowrap` to `.top-posts-list a`.
- **Bug went live:** #335 ("Show sidebar … on mobile/tablet") — before it, `.sidebar` was `display:none` below 1024px; #335 made it visible and stacked it into the collapsed grid without accounting for the nowrap content.

## Why tests didn't catch it

`tests/mobile.spec.ts` already had a correct overflow check (it does fail on the buggy CSS), but with two gaps:

1. **Network-dependent false pass** — Popular posts are injected async from a remote endpoint. A fixed `waitForTimeout(1000)` meant a slow/down endpoint left the sidebar empty (narrow) and the check silently passed. The over-wide titles are the *only* thing that triggers the bug.
2. **Only 375px** — the `html,body { overflow-x: hidden }` safety net only applies ≤640px, so tablet-width overflow was untested.

Test changes:
- Wait for the Popular posts widget to actually populate before asserting (fails loudly if it never does).
- Run the overflow check at tablet (768px) as well as mobile (375px).
- Also assert `documentElement.scrollWidth`, which `body.scrollWidth` masks below 640px.

## Verification

- Reproduced the bug at 375px (`bodyScrollWidth` 515 vs viewport 375); after the fix it's 375.
- Confirmed the hardened test **fails** on the reverted CSS and **passes** on the fix.
- Full Playwright suite: **72 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)