### PR TITLE
Redesign Interesting Links landing page

### DIFF
--- a/layouts/categories/term.html
+++ b/layouts/categories/term.html
@@ -26,29 +26,39 @@
     {{ end }}
 
     {{- $ilPages := where .Pages ".Params.skip" "ne" "true" -}}
-    <div class="il-landing">
-        <div class="il-landing-card il-landing-latest">
+    <div class="il-page-grid">
+        <div class="il-landing-card il-landing-latest il-page-grid-latest">
             {{- with index (sort $ilPages "Date" "desc") 0 }}
-            <div class="il-landing-label">Latest issue</div>
-            <a class="il-landing-latest-link" href="{{ .RelPermalink }}">
-                <span class="il-landing-latest-title">{{ .Title }}</span>
-                <span class="il-landing-arrow" aria-hidden="true">&rarr;</span>
+            <a class="il-landing-latest-thumb" href="{{ .RelPermalink }}" aria-hidden="true" tabindex="-1">
+                {{ partial "thumbnail.html" (dict "page" . "variant" "featured-image") }}
             </a>
-            <div class="il-landing-date">{{ .Date.Format "02 Jan 2006" }}</div>
-            {{- end }}
-            <div class="il-landing-subscribe">
-                <p>📧 Get these every month by email:</p>
-                <a class="il-landing-sub-btn" href="https://interestinglinks.substack.com/subscribe">Subscribe on Substack ↗</a>
+            <div class="il-landing-latest-body">
+                <div class="il-landing-label">Latest issue</div>
+                <a class="il-landing-latest-link" href="{{ .RelPermalink }}">
+                    <span class="il-landing-latest-title">{{ .Title }}</span>
+                    <span class="il-landing-arrow" aria-hidden="true">&rarr;</span>
+                </a>
+                <div class="il-landing-date">{{ .Date.Format "02 Jan 2006" }}</div>
+                <div class="il-landing-subscribe">
+                    <p>📧 Get these every month by email:</p>
+                    <a class="il-landing-sub-btn" href="https://interestinglinks.substack.com/subscribe">Subscribe on Substack ↗</a>
+                </div>
             </div>
+            {{- end }}
         </div>
-        <aside class="il-landing-card popular-links popular-links--landing" data-limit="10" data-heading="🔥 Most-clicked links" data-heading-note="since March 2026"></aside>
-    </div>
+        <aside class="il-landing-card popular-links popular-links--landing il-page-grid-rail" data-limit="10" data-heading="🔥 Most-clicked links" data-heading-note="since March 2026"></aside>
+        <div class="il-page-grid-archive">
     {{ end }}
 
     <div id="category-search-results" style="display: none;"></div>
 
     <div id="category-article-list">
         {{- $pages := where .Pages ".Params.skip" "ne" "true" -}}
+        {{- if eq .Title "Interesting Links" -}}
+            {{- /* The latest issue is featured in the card above, so drop it here */ -}}
+            {{- $pages = after 1 (sort $pages "Date" "desc") -}}
+        <h2 class="il-previous-heading">Previous issues</h2>
+        {{- end -}}
         {{- $.Scratch.Set "currentYear" "" -}}
         {{- $.Scratch.Set "articleCount" 0 -}}
         {{- $minVisible := 10 -}}
@@ -72,6 +82,10 @@
             </details>
         {{- end }}
     </div>
+    {{ if eq .Title "Interesting Links" }}
+        </div>
+    </div>
+    {{ end }}
 </div>
 
 <script>

--- a/static/css/redesign.css
+++ b/static/css/redesign.css
@@ -3392,17 +3392,43 @@ li.il-hidden {
    Interesting Links landing band (category page)
    ========================================================================== */
 
-.il-landing {
+/* Two-column landing: main column (latest + archive) beside a sticky rail */
+.il-page-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1.5rem;
+  /* Archive rows are short, so let the most-clicked rail claim the slack */
+  grid-template-columns: minmax(0, 1fr) clamp(320px, 36%, 460px);
+  grid-template-areas:
+    "latest  rail"
+    "archive rail";
+  gap: 1.5rem 2.5rem;
   align-items: start;
   margin: 1.5rem 0 2.5rem;
 }
 
-@media (max-width: 768px) {
-  .il-landing {
+.il-page-grid-latest  { grid-area: latest; }
+.il-page-grid-archive { grid-area: archive; min-width: 0; }
+
+.il-page-grid-rail {
+  grid-area: rail;
+  position: sticky;
+  top: 1.5rem;
+  align-self: start;
+  max-height: calc(100vh - 3rem);
+  overflow-y: auto;
+}
+
+@media (max-width: 900px) {
+  .il-page-grid {
     grid-template-columns: 1fr;
+    grid-template-areas:
+      "latest"
+      "rail"
+      "archive";
+  }
+  .il-page-grid-rail {
+    position: static;
+    max-height: none;
+    overflow-y: visible;
   }
 }
 
@@ -3411,6 +3437,55 @@ li.il-hidden {
   background: var(--color-border-light);
   border: 1px solid var(--color-border);
   padding: 1.25rem 1.4rem;
+}
+
+/* Match the "Latest issue" eyebrow label exactly (see .il-landing-label) */
+.il-previous-heading {
+  font-family: var(--font-ui);
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  margin: 0 0 0.75rem;
+}
+
+/* Latest-issue card: horizontal (image left, details right) on wide screens */
+.il-landing-card.il-landing-latest {
+  display: grid;
+  grid-template-columns: minmax(0, 300px) 1fr;
+  padding: 0;
+  overflow: hidden;
+}
+
+.il-landing-latest-thumb {
+  display: block;
+  height: 100%;
+}
+
+.il-landing-latest-thumb img,
+.il-landing-latest-thumb .featured-post-image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.il-landing-latest-body {
+  display: flex;
+  flex-direction: column;
+  padding: 1.25rem 1.4rem;
+}
+
+@media (max-width: 560px) {
+  .il-landing-card.il-landing-latest {
+    grid-template-columns: 1fr;
+  }
+  .il-landing-latest-thumb img,
+  .il-landing-latest-thumb .featured-post-image {
+    height: auto;
+    aspect-ratio: 16 / 9;
+  }
 }
 
 .il-landing-label {


### PR DESCRIPTION
Reworks the **Interesting Links** category landing page (`/categories/interesting-links/`).

## Changes
- **Fix missing card image** — the "Latest issue" card never rendered a thumbnail (unlike regular index rows). Now uses the existing `thumbnail.html` partial.
- **Latest-issue card is horizontal** (image left, details right) so it stays compact.
- **Most-clicked links moved to a sticky right rail** running *alongside* the year archive instead of stacking above it — previously its height pushed the archive below the fold. The rail flexes (`clamp(320px, 36%, 460px)`) to use available width so long link titles wrap less.
- **De-duplicated the latest issue** — it's featured in the card, so it's dropped from the archive list, which now sits under a **"Previous issues"** heading styled to match the "Latest issue" label.
- **Mobile (<900px)** stacks: latest → most-clicked → archive.

Non-IL category pages are unaffected (changes are gated behind `eq .Title "Interesting Links"`).

## Testing
- Full Playwright suite run against a Docker dev server (`serve.sh` image). No new failures vs. baseline — the 15 failures are pre-existing (Pagefind search is disabled under `hugo server` dev mode, plus the callout-lists CSS specs) and identical with or without this change.
- `mobile.spec.ts` passes 20/20, including no-horizontal-overflow on the categories / interesting-links / category-term pages.
- Verified rendering and computed styles via Playwright at desktop (1280/1440), tablet, and mobile (390) widths.

> Note: the most-clicked rail is empty when previewed from `localhost` because the data Worker only allows the `rmoff.net` origin (CORS). It populates in production / PR previews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)